### PR TITLE
fix(ci): improve branch comparison logic in develop-to-master PR work…

### DIFF
--- a/.github/workflows/develop-to-master-pr.yml
+++ b/.github/workflows/develop-to-master-pr.yml
@@ -62,9 +62,10 @@ jobs:
         id: check_diff
         if: steps.check-pr.outputs.skip != 'true' && steps.check-branches.outputs.skip != 'true'
         run: |
-          # Fetch latest master and develop just in case
-          git fetch origin master:master develop:develop
-          changes=$(git log master..develop --oneline)
+          # Fetch latest master and develop branches from origin
+          git fetch origin master develop
+          # Compare remote tracking branches to avoid issues with local state
+          changes=$(git log origin/master..origin/develop --oneline)
           if [ -z "$changes" ]; then
             echo "No changes detected between develop and master. Skipping PR creation."
             echo "skip_pr_creation=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/develop-to-master-pr.yml` file to improve the accuracy of detecting changes between the `develop` and `master` branches.

Improvements to change detection:

* [`.github/workflows/develop-to-master-pr.yml`](diffhunk://#diff-f4d25b6b3bd50ddb538f57c57b2a62aa5e8b7195130720c50b13c509bd6512f9L65-R68): Updated the `check_diff` step to fetch the latest `master` and `develop` branches from the remote repository and compare the remote tracking branches instead of the local branches. This ensures that the comparison is accurate and not affected by the local state.…flow