### PR TITLE
fix(ci): update git log command to use origin references for change l…

### DIFF
--- a/.github/workflows/develop-to-master-pr.yml
+++ b/.github/workflows/develop-to-master-pr.yml
@@ -96,7 +96,7 @@ jobs:
 
           # 変更ログを生成
           set +e  # エラーが発生してもスクリプトを継続
-          changes=$(git log master..develop --pretty=format:'- %s' --reverse 2>/dev/null)
+          changes=$(git log origin/master..origin/develop --pretty=format:'- %s' --reverse 2>/dev/null)
           exit_code=$?
           set -e  # エラーハンドリングを再度有効化
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/develop-to-master-pr.yml` file. The change modifies the command used to generate the change log to ensure it correctly references the remote branches.

* [`.github/workflows/develop-to-master-pr.yml`](diffhunk://#diff-f4d25b6b3bd50ddb538f57c57b2a62aa5e8b7195130720c50b13c509bd6512f9L99-R99): Updated the `git log` command to use `origin/master` and `origin/develop` instead of `master` and `develop` for generating the change log