### PR TITLE
fix(mcp): update asset copy paths and remove unnecessary whitespace

### DIFF
--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -10,7 +10,7 @@ import path from 'node:path';
 async function copyDir(src, dest) {
   // ディレクトリがなければ作成
   await fs.mkdir(dest, { recursive: true });
-  
+
   // ディレクトリ内の全エントリを取得
   const entries = await fs.readdir(src, { withFileTypes: true });
 
@@ -18,7 +18,7 @@ async function copyDir(src, dest) {
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
-    
+
     // ディレクトリなら再帰的にコピー
     if (entry.isDirectory()) {
       await copyDir(srcPath, destPath);
@@ -33,18 +33,18 @@ async function copyDir(src, dest) {
 async function main() {
   try {
     console.log('🔍 コピー開始...');
-    
+
     // 翻訳ファイルをコピー
     await copyDir(
-      'src/infrastructure/i18n/translations', 
-      'dist/infrastructure/i18n/translations'
+      'packages/mcp/src/infrastructure/i18n/translations',
+      'packages/mcp/dist/infrastructure/i18n/translations'
     );
     console.log('✅ 翻訳ファイルをコピーしました！');
-    
+
     // テンプレートをコピー
     await copyDir('src/templates', 'dist/templates');
     console.log('✅ テンプレートをコピーしました！');
-    
+
     console.log('✨ すべてのアセットを正常にコピーしました！');
   } catch (error) {
     console.error('❌ エラーが発生しました:', error);


### PR DESCRIPTION
This pull request includes a change to the `scripts/copy-assets.js` file to update the paths for copying translation files.

* [`scripts/copy-assets.js`](diffhunk://#diff-c09ab817828733799eca92ef5549fb39e30d30561fe53cdbd6c244795a251c62L39-R40): Updated the source and destination paths for copying translation files to reflect the new directory structure.