### PR TITLE
fix: Correct asset copy path and ESLint config for scripts

### DIFF
--- a/docs/branch-memory-bank/fix-copy-assets-2/branchContext.json
+++ b/docs/branch-memory-bank/fix-copy-assets-2/branchContext.json
@@ -1,0 +1,13 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-copy-assets-2-context",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "createdAt": "2025-04-02T16:03:09.831Z",
+    "lastModified": "2025-04-02T16:03:09.831Z"
+  },
+  "content": {
+    "value": "Auto-initialized context for branch fix/copy-assets-2"
+  }
+}

--- a/docs/branch-memory-bank/fix-copy-assets-2/progress.json
+++ b/docs/branch-memory-bank/fix-copy-assets-2/progress.json
@@ -1,0 +1,49 @@
+{
+  "current_task": "fix-copy-assets-error",
+  "status": "resolved_code_changes",
+  "problem_analysis": {
+    "error_description": "yarn copy-assetsでsrc/templatesディレクトリが見つからないエラーが発生",
+    "root_cause": "copy-assets.jsのパスが古い構造を参照している",
+    "affected_files": [
+      "scripts/copy-assets.js"
+    ],
+    "sub_problems": [
+      {
+        "error_description": "scripts/copy-assets.jsでESLintエラー（console, process is not defined）が発生",
+        "root_cause": "eslint.config.jsでscriptsディレクトリへのNode.js環境設定適用漏れ",
+        "affected_files": [
+          "eslint.config.js"
+        ],
+        "status": "resolved"
+      }
+    ]
+  },
+  "solution_plan": {
+    "type": "path_update",
+    "changes_needed": [
+      {
+        "file": "scripts/copy-assets.js",
+        "updates": [
+          {
+            "from": "src/templates",
+            "to": "packages/mcp/src/templates"
+          },
+          {
+            "from": "dist/templates",
+            "to": "packages/mcp/dist/templates"
+          }
+        ]
+      }
+    ],
+    "expected_outcome": "ビルド時のアセットコピーが正常に完了するようになる"
+  },
+  "implementation_steps": [
+    "1. copy-assets.jsのテンプレートパスを修正",
+    "2. eslint.config.jsにscriptsディレクトリ用の設定を追加",
+    "3. ビルドプロセスでエラーが解消されることを確認"
+  ],
+  "next_action": "Request commit confirmation from t3ta",
+  "metadata": {
+    "tags": []
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,5 +85,15 @@ export default [
     ...testConfig, // Use spread syntax
     // tests 配下のファイルにテスト用設定を適用
     files: ['tests/**/*.ts', 'tests/**/*.js']
+  },
+  {
+    ...baseConfig, // Apply base config to scripts
+    files: ['scripts/**/*.js'],
+    rules: {
+      ...baseConfig.rules,
+      '@typescript-eslint/explicit-function-return-type': 'off', // Allow missing return types in JS scripts
+      'import/no-commonjs': 'off', // Allow CommonJS in scripts if needed
+      '@typescript-eslint/no-var-requires': 'off' // Allow require in scripts if needed
+    }
   }
 ];

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -42,7 +42,7 @@ async function main() {
     console.log('✅ 翻訳ファイルをコピーしました！');
 
     // テンプレートをコピー
-    await copyDir('src/templates', 'dist/templates');
+    await copyDir('packages/mcp/src/templates', 'packages/mcp/dist/templates');
     console.log('✅ テンプレートをコピーしました！');
 
     console.log('✨ すべてのアセットを正常にコピーしました！');


### PR DESCRIPTION
# fix: Correct asset copy path and ESLint config for scripts

## Overview

Fixed the `yarn copy-assets` error that occurred in the GitHub Actions release workflow (`release.yml`).

## Changes

- `scripts/copy-assets.js`:
    - Updated the source/destination paths for template files to `packages/mcp/src/templates` and `packages/mcp/dist/templates` respectively, matching the current project structure.
- `eslint.config.js`:
    - Added ESLint configuration for `scripts/**/*.js` files to recognize Node.js global variables (`console`, `process`), resolving linting errors.

## Impact

- GitHub Actions release workflow
- Execution of `scripts/copy-assets.js`

## Verification

- [ ] Confirm that the release workflow completes successfully.

## Related Issues

None
