### PR TITLE
fix(release): use shell script for cross-platform sed in prepareCmd

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -58,7 +58,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i '' 's/(v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+)/(v${nextRelease.version})/' packages/mcp/README.md && echo 'Updated README version for mcp package.'"
+        "prepareCmd": "./scripts/update-readme-version.sh ${nextRelease.version}"
       }
     ],
     "@semantic-release/github",

--- a/docs/branch-memory-bank/fix-semantic-release/branchContext.json
+++ b/docs/branch-memory-bank/fix-semantic-release/branchContext.json
@@ -1,0 +1,13 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-semantic-release-context",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "createdAt": "2025-04-02T16:19:17.047Z",
+    "lastModified": "2025-04-02T16:19:17.047Z"
+  },
+  "content": {
+    "value": "Auto-initialized context for branch fix/semantic-release"
+  }
+}

--- a/docs/branch-memory-bank/fix-semantic-release/progress.json
+++ b/docs/branch-memory-bank/fix-semantic-release/progress.json
@@ -1,0 +1,36 @@
+{
+  "tasks": [
+    {
+      "title": "semantic-releaseのsedコマンド修正",
+      "description": "Linux環境でsedコマンドが失敗する問題を修正する",
+      "status": "done",
+      "plan": {
+        "steps": [
+          {
+            "title": "シェルスクリプトの作成",
+            "description": "OSに応じたsed構文を適切に使い分けるシェルスクリプトを作成",
+            "path": "scripts/update-readme-version.sh"
+          },
+          {
+            "title": ".releaserc.jsonの更新",
+            "description": "作成したシェルスクリプトを使用するように設定を変更"
+          }
+        ]
+      },
+      "technical_details": {
+        "issue": "Linuxのsedコマンドで-i ''オプションが動作しない",
+        "solution": "OSタイプに応じて適切なsed構文を使用するシェルスクリプトを作成して対応"
+      },
+      "results": {
+        "summary": "semantic-releaseのsedコマンドエラーを修正完了",
+        "files_modified": [
+          "scripts/update-readme-version.sh",
+          ".releaserc.json"
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "tags": []
+  }
+}

--- a/scripts/update-readme-version.sh
+++ b/scripts/update-readme-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Check if version argument is provided
+if [ -z "$1" ]; then
+  echo "Error: New version argument is required."
+  exit 1
+fi
+
+NEW_VERSION=$1
+README_PATH="packages/mcp/README.md"
+
+# Check if README file exists
+if [ ! -f "$README_PATH" ]; then
+  echo "Error: README file not found at $README_PATH"
+  exit 1
+fi
+
+echo "Updating README version in $README_PATH to v$NEW_VERSION..."
+
+# Use different sed syntax based on OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS (BSD sed)
+    sed -i '' "s/(v[0-9]\+\.[0-9]\+\.[0-9]\+)/(v$NEW_VERSION)/g" "$README_PATH"
+else
+    # Linux (GNU sed)
+    sed -i "s/(v[0-9]\+\.[0-9]\+\.[0-9]\+)/(v$NEW_VERSION)/g" "$README_PATH"
+fi
+
+if [ $? -eq 0 ]; then
+  echo "README version updated successfully."
+else
+  echo "Error: Failed to update README version."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
# PR Title: fix(release): Resolve semantic-release failure on Linux due to sed incompatibility

## Description

This PR addresses an issue where the `semantic-release` process fails during the `prepare` step within Linux environments (like GitHub Actions runners). The failure is caused by incompatible `sed` command syntax used in the `@semantic-release/exec` plugin's `prepareCmd` within `.releaserc.json`.

The `sed -i '' ...` syntax is specific to macOS (BSD sed) and causes errors on Linux (GNU sed).

## Changes

- **Created `scripts/update-readme-version.sh`:** A new shell script that detects the operating system (`OSTYPE`) and uses the appropriate `sed -i` syntax (either with `''` for macOS or without for Linux) to update the version number in `packages/mcp/README.md`.
- **Updated `.releaserc.json`:** Modified the `prepareCmd` for the `@semantic-release/exec` plugin to execute the new `scripts/update-readme-version.sh` script, passing the `${nextRelease.version}` as an argument. This ensures cross-platform compatibility for the README version update step.
- **Added execute permissions** to `scripts/update-readme-version.sh`.

## How to Test

This change primarily affects the CI/CD pipeline. Verification involves running the release process (e.g., via a push to the `master` branch or a manual workflow trigger if available) on a Linux-based environment and confirming that the `prepare` step completes successfully without `sed` errors.

## Related Issues

(If any, link related issues here)
