### PR TITLE
ci(release): Use PAT to bypass branch protection rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Run semantic-release
         id: semantic # Add an ID to potentially reference outputs if needed
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # Uncomment if publishing to npm
+          # Use PAT to bypass branch protection rules
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn release
 
       - name: Build, Package and Upload VSCode Extension VSIX
@@ -68,4 +69,5 @@ jobs:
           # Upload the VSIX to the GitHub Release created by semantic-release
           gh release upload ${{ github.ref_name }} packages/vscode-extension/$VSIX_FILENAME --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to bypass branch protection rules
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
# PR Draft for fix/bypass-branch-protection

## Title

ci(release): Use PAT to bypass branch protection rules

## Body

### Description

This PR updates the release workflow (`.github/workflows/release.yml`) to use a Personal Access Token (PAT) stored in `secrets.PAT_TOKEN` instead of the default `secrets.GITHUB_TOKEN`.

This change is necessary to bypass repository rules that require pull requests for direct pushes to the `master` branch, allowing `semantic-release` to commit version bumps, update the changelog, and push tags directly during the release process.

The `NPM_TOKEN` environment variable has also been uncommented in preparation for future npm publishing, although publishing is currently disabled in `.releaserc.json`.

**Note:** This workflow requires a `PAT_TOKEN` secret to be configured in the repository settings with `repo` and `workflow` scopes.
