### PR TITLE
feat(ci): implement PR-based release workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,143 @@
+# .github/workflows/release-prepare.yml
+name: Prepare Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to analyze commits from (usually develop)'
+        required: true
+        default: 'develop'
+
+permissions:
+  contents: write # Needed to commit and push the release branch
+  pull-requests: write # Needed to create the pull request
+
+jobs:
+  prepare-release:
+    name: Prepare Release PR
+    runs-on: ubuntu-latest
+    # Prevent running on forks
+    if: github.repository == 't3ta/memory-bank-mcp-server'
+    steps:
+      - name: Checkout target branch (${{ github.event.inputs.branch }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          # Fetch all history and tags for semantic-release
+          fetch-depth: 0
+          # Use PAT to allow pushing the new branch
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packages
+        run: |
+          yarn build
+          yarn copy-assets
+
+      - name: Get next version and release notes (Dry Run)
+        id: get_version
+        # Run semantic-release in dry-run mode to get info without publishing
+        # Redirect stderr to stdout to capture all output
+        run: |
+          npx semantic-release --dry-run --branches ${{ github.event.inputs.branch }} > semantic_output.log 2>&1 || true
+          echo "--- Semantic Release Output ---"
+          cat semantic_output.log
+          echo "-------------------------------"
+          # Extract next version (adjust regex if needed)
+          VERSION=$(grep -oP 'The next release version is \K([0-9]+\.[0-9]+\.[0-9]+)' semantic_output.log || echo "")
+          # Extract release notes (this is tricky, might need adjustment)
+          # Assuming notes start after "## Features" or "## Bug Fixes" etc. and end before the next step log
+          NOTES=$(awk '/Published release/ {exit} flag; /## \[?[0-9]+\.[0-9]+\.[0-9]+\]?/ {flag=1}' semantic_output.log || echo "")
+          if [ -z "$VERSION" ]; then
+            echo "Could not determine next version from semantic-release output."
+            # Check if there are no changes detected
+            if grep -q "There are no relevant changes, so no new version is released." semantic_output.log; then
+              echo "No relevant changes detected. Exiting."
+              # Set output to indicate no version bump needed
+              echo "NEXT_VERSION=" >> $GITHUB_OUTPUT
+              exit 0 # Exit successfully, no PR needed
+            else
+              exit 1 # Exit with error if version couldn't be determined otherwise
+            fi
+          fi
+          echo "NEXT_VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          # Store notes in an environment variable (might be large)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Update package.json version
+        if: steps.get_version.outputs.NEXT_VERSION
+        run: |
+          echo "Updating package.json to version ${{ steps.get_version.outputs.NEXT_VERSION }}"
+          # Use npm version to update package.json without creating a git tag
+          npm version ${{ steps.get_version.outputs.NEXT_VERSION }} --no-git-tag-version --allow-same-version
+
+      - name: Update CHANGELOG.md
+        if: steps.get_version.outputs.NEXT_VERSION
+        run: |
+          echo "Updating CHANGELOG.md"
+          # Use conventional-changelog-cli to prepend the latest changes
+          # Ensure CHANGELOG.md exists, create if not
+          touch CHANGELOG.md
+          npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s -r 0
+          # Add a header for the new version only if the file was modified or created
+          if ! git diff --quiet CHANGELOG.md; then
+            sed -i '1s/^/# \[${{ steps.get_version.outputs.NEXT_VERSION }}] - $(date +%Y-%m-%d)\n\n/' CHANGELOG.md
+          fi
+
+      - name: Update README version
+        if: steps.get_version.outputs.NEXT_VERSION
+        run: |
+          echo "Updating README version"
+          ./scripts/update-readme-version.sh ${{ steps.get_version.outputs.NEXT_VERSION }}
+
+      - name: Create Release Branch and Commit Changes
+        if: steps.get_version.outputs.NEXT_VERSION
+        id: commit_branch # Give this step an ID
+        run: |
+          VERSION=${{ steps.get_version.outputs.NEXT_VERSION }}
+          BRANCH_NAME="release/v${VERSION}"
+          echo "Creating release branch: ${BRANCH_NAME}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # Check if there are changes to commit before creating branch/committing
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes detected to commit."
+            # Set output to indicate no branch was created
+            echo "BRANCH_NAME=" >> $GITHUB_OUTPUT
+          else
+            git checkout -b ${BRANCH_NAME}
+            git add .
+            git commit -m "chore(release): prepare release v${VERSION}"
+            git push origin ${BRANCH_NAME}
+            echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        # Only run if a branch was created and pushed
+        if: steps.commit_branch.outputs.BRANCH_NAME
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }} # Use PAT for PR creation as well
+          BRANCH_NAME: ${{ steps.commit_branch.outputs.BRANCH_NAME }}
+          VERSION: ${{ steps.get_version.outputs.NEXT_VERSION }}
+          # RELEASE_NOTES is available from the previous step's env
+        run: |
+          echo "Creating Pull Request for ${BRANCH_NAME}"
+          # Use gh cli to create the pull request
+          gh pr create \
+            --base master \
+            --head ${BRANCH_NAME} \
+            --title "chore(release): prepare release v${VERSION}" \
+            --body "This PR was automatically generated to prepare for release v${VERSION}.
+
+          **Release Notes:**
+          ${RELEASE_NOTES:-*No release notes generated by semantic-release.*}"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -91,7 +91,8 @@ jobs:
           npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s -r 0
           # Add a header for the new version only if the file was modified or created
           if ! git diff --quiet CHANGELOG.md; then
-            sed -i '1s/^/# \[${{ steps.get_version.outputs.NEXT_VERSION }}] - $(date +%Y-%m-%d)\n\n/' CHANGELOG.md
+            VERSION=${{ steps.get_version.outputs.NEXT_VERSION }}
+            sed -i "1s/^/# [${VERSION}] - $(date +%Y-%m-%d)\n\n/" CHANGELOG.md
           fi
 
       - name: Update README version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,102 @@
+# .github/workflows/release-publish.yml
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - master
+    # Only run on pushes that include the release commit message
+    # This prevents running on every push to master
+    paths:
+      - 'package.json' # Assuming version bump always changes package.json
+
+permissions:
+  contents: write # Needed to create releases and tags
+  # issues: write # Potentially needed if linking issues in release notes
+  # pull-requests: write # Potentially needed if linking PRs
+
+jobs:
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    # Prevent running on forks
+    if: |
+      github.repository == 't3ta/memory-bank-mcp-server' &&
+      contains(github.event.head_commit.message, 'chore(release): prepare release v')
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          # Fetch all history and tags for semantic-release (though not strictly needed here)
+          fetch-depth: 0
+          # Use PAT for potential future operations needing push access
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          # Optional: Configure registry for npm publish if needed later
+          # registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # No build needed if artifacts are not required for release assets
+
+      - name: Get Version from package.json
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create Git Tag
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }} # Use PAT for tag creation
+          VERSION: ${{ steps.get_version.outputs.PACKAGE_VERSION }}
+        run: |
+          echo "Creating Git tag v${VERSION}"
+          # Create an annotated tag
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }} # Use PAT for release creation
+          VERSION: ${{ steps.get_version.outputs.PACKAGE_VERSION }}
+        run: |
+          echo "Creating GitHub Release for v${VERSION}"
+          # Extract release notes from CHANGELOG.md for this version
+          # This assumes CHANGELOG format like: # [X.Y.Z] ... \n\n ... # [X.Y.Z-1]
+          # Ensure CHANGELOG.md exists before trying to read
+          if [ ! -f CHANGELOG.md ]; then
+            echo "CHANGELOG.md not found. Cannot extract release notes."
+            NOTES="*CHANGELOG.md not found.*"
+          else
+            NOTES=$(awk "/^# \\[${VERSION}\]/{flag=1; next} /^# \\[/ && flag{flag=0; exit} flag" CHANGELOG.md)
+            # Handle case where version header is not found or notes are empty
+            if [ -z "$NOTES" ]; then
+              NOTES="*Could not extract release notes from CHANGELOG.md. See the file for details.*"
+            fi
+          fi
+          # Create release using gh cli
+          gh release create "v${VERSION}" \
+            --title "Release v${VERSION}" \
+            --notes "${NOTES}" \
+            --target master # Explicitly target master
+
+      # --- Optional: Publish to npm ---
+      # - name: Publish to npm
+      #   if: steps.get_version.outputs.PACKAGE_VERSION # Ensure version was read
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   run: |
+      #     echo "Publishing version ${{ steps.get_version.outputs.PACKAGE_VERSION }} to npm"
+      #     # Add publishConfig to root package.json if needed, or publish workspaces individually
+      #     npm publish --access public # Adjust access level if needed
+
+      # --- Optional: Upload VSCode Extension ---
+      # Similar logic as in the original release.yml, triggered by tag push maybe?
+      # Or integrate here if the VSIX should be part of the main release assets.
+      # Needs careful consideration of how/when the VSIX is built.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -61,13 +61,6 @@
         "prepareCmd": "./scripts/update-readme-version.sh ${nextRelease.version}"
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "packages/**/package.json", "CHANGELOG.md", "packages/mcp/README.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
# PR Draft for fix/release-pr

## Title

feat(ci): implement PR-based release workflow

## Body

### Description

This PR implements a new pull-request-based release workflow to address issues with branch protection rules preventing direct pushes to `master` by `semantic-release`.

**Changes:**

1.  **Added `.github/workflows/release-prepare.yml`:**
    *   Manually triggered via `workflow_dispatch`.
    *   Runs `semantic-release --dry-run` on a specified branch (e.g., `develop`) to determine the next version and generate release notes.
    *   Updates `package.json`, `CHANGELOG.md`, and README files with the new version.
    *   Creates a `release/vX.Y.Z` branch containing these changes.
    *   Opens a pull request from the `release/vX.Y.Z` branch to `master`.

2.  **Added `.github/workflows/release-publish.yml`:**
    *   Triggered automatically when a commit with the message `chore(release): prepare release v...` is pushed to `master` (i.e., when the release PR is merged).
    *   Reads the version from the merged `package.json`.
    *   Creates the corresponding Git tag (`vX.Y.Z`).
    *   Creates a GitHub Release, using the relevant section from `CHANGELOG.md` as release notes.

3.  **Modified `.releaserc.json`:**
    *   Removed the `@semantic-release/git` plugin. This prevents `semantic-release` from attempting to commit and push changes directly during the `release-prepare` workflow, allowing the workflow to handle file changes and PR creation instead.

**Workflow:**

1.  Manually trigger `release-prepare.yml` targeting the `develop` branch.
2.  Review and merge the automatically created `release/vX.Y.Z` -> `master` PR.
3.  `release-publish.yml` automatically triggers on merge, creating the tag and GitHub Release.

This approach maintains branch protection while automating versioning, changelog updates, and release creation through a reviewable PR process.
