### PR TITLE
feat: Automatically detect branch name in project mode (#72)

### DIFF
--- a/docs/branch-memory-bank/fix-issue-76/branchContext.json
+++ b/docs/branch-memory-bank/fix-issue-76/branchContext.json
@@ -1,0 +1,13 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-76-context",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "createdAt": "2025-04-03T11:08:25.300Z",
+    "lastModified": "2025-04-03T11:08:25.300Z"
+  },
+  "content": {
+    "value": "Auto-initialized context for branch fix/issue-76"
+  }
+}

--- a/docs/branch-memory-bank/fix-issue-76/progress.json
+++ b/docs/branch-memory-bank/fix-issue-76/progress.json
@@ -1,0 +1,32 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-76-progress",
+    "title": "fix/issue-76 作業進捗",
+    "documentType": "progress_log",
+    "path": "progress.json",
+    "tags": [
+      "progress",
+      "issue-76"
+    ],
+    "createdAt": "2025-04-03T11:12:30Z",
+    "lastModified": "2025-04-03T11:12:30Z",
+    "version": 1
+  },
+  "content": {
+    "tasks": [
+      {
+        "id": "implement-issue-72",
+        "summary": "Issue #72: ブランチ名自動検出機能の実装",
+        "status": "完了",
+        "details": [
+          "GitService を作成し、現在のブランチ名を取得する機能を追加",
+          "ReadBranchDocumentUseCase と WriteBranchDocumentUseCase を修正し、branchName が省略された場合に GitService を利用するように変更",
+          "BranchController の readDocument/writeDocument メソッドで branchName をオプショナルに変更",
+          "DIコンテナ (providers.ts) を修正し、GitService を UseCase に注入"
+        ],
+        "completedAt": "2025-04-03T11:12:30Z"
+      }
+    ]
+  }
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,7 +1,5 @@
 # @memory-bank/mcp (v2.3.5)
 
-<!-- Demo change for semantic-release -->
-
 This package provides the core implementation of the Memory-enabled Co-Pilot (MCP) server for managing project documentation and context.
 
 ## Overview
@@ -51,7 +49,7 @@ yarn workspace @memory-bank/mcp dev --docs /path/to/your/docs
 
 **Server Options:**
 
-- `--docs, -d`: **Required.** Path to the project's documentation directory (containing `global-memory-bank` and `branch-memory-bank`).
+- `--docs, -d`: **Required.** Path to the project's documentation directory (containing `global-memory-bank` and `branch-memory-bank`). Specifying this (or using environment variables `MEMORY_BANK_ROOT` or `DOCS_ROOT`) enables **Project Mode**, which allows features like automatic Git branch detection.
 - `--verbose, -v`: Enable verbose logging (default: false).
 - `--language, -l`: Default language for templates ('en', 'ja' or 'zh', default: 'en').
 
@@ -59,8 +57,8 @@ yarn workspace @memory-bank/mcp dev --docs /path/to/your/docs
 
 Once the server is running, clients interact with it using the defined MCP tools. Refer to the core tool manual (`docs/global-memory-bank/core/mcp-tool-manual.json`) for details on available tools like:
 
-- `write_branch_memory_bank`
-- `read_branch_memory_bank`
+- `write_branch_memory_bank`: Writes a document to a branch. The `branch` parameter is optional in Project Mode (uses current Git branch).
+- `read_branch_memory_bank`: Reads a document from a branch. The `branch` parameter is optional in Project Mode (uses current Git branch).
 - `write_global_memory_bank`
 - `read_global_memory_bank`
 - `read_context`

--- a/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
@@ -6,15 +6,16 @@ import { BranchInfo } from '../../../domain/entities/BranchInfo.js';
 import { DomainErrors } from '../../../shared/errors/DomainError.js';
 import { ApplicationErrors, ErrorUtils } from '../../../shared/errors/index.js';
 import { logger } from '../../../shared/utils/logger.js';
+import type { IGitService } from '@/infrastructure/git/IGitService.js';
 
 /**
  * Input data for read branch document use case
  */
 export interface ReadBranchDocumentInput {
   /**
-   * Branch name
+   * Branch name (optional, will be detected if not provided)
    */
-  branchName: string;
+  branchName?: string;
 
   /**
    * Document path
@@ -45,7 +46,10 @@ export class ReadBranchDocumentUseCase
    * Constructor
    * @param branchRepository Branch memory bank repository
    */
-  constructor(private readonly branchRepository: IBranchMemoryBankRepository) {}
+  constructor(
+    private readonly branchRepository: IBranchMemoryBankRepository,
+    private readonly gitService: IGitService
+  ) {}
 
   /**
    * Execute the use case
@@ -53,25 +57,38 @@ export class ReadBranchDocumentUseCase
    * @returns Promise resolving to output data
    */
   async execute(input: ReadBranchDocumentInput): Promise<ReadBranchDocumentOutput> {
+    let branchNameToUse = input.branchName;
+
+    if (!branchNameToUse) {
+      try {
+        branchNameToUse = await this.gitService.getCurrentBranchName();
+        this.useCaseLogger.info(`Current branch name automatically detected: ${branchNameToUse}`);
+      } catch (error) {
+        this.useCaseLogger.error('Failed to get current branch name', { error });
+        // エラーメッセージをちょっと親切に
+        throw ApplicationErrors.invalidInput('Branch name is required but could not be automatically determined. Please provide it explicitly or ensure you are in a Git repository.');
+      }
+    }
+
     this.useCaseLogger.info('Executing read branch document use case', {
-      branchName: input.branchName,
+      branchName: branchNameToUse,
       documentPath: input.path
     });
 
-    if (!input.branchName) {
-      throw ApplicationErrors.invalidInput('Branch name is required');
-    }
-
+    // pathのチェックはそのまま
     if (!input.path) {
       throw ApplicationErrors.invalidInput('Document path is required');
     }
 
     return await ErrorUtils.wrapAsync(
-      this.executeInternal(input),
+      // みらい変更：executeInternalには確定したブランチ名を渡す
+      // みらい修正：branchNameToUseがstringなのは確定してるから `!` で教えてあげる
+      this.executeInternal({ ...input, branchName: branchNameToUse! }),
       (error) => ApplicationErrors.executionFailed(
         'ReadBranchDocumentUseCase',
         error instanceof Error ? error : undefined,
-        { input }
+        // みらい変更：エラーログにも確定したブランチ名を含める
+        { input: { ...input, branchName: branchNameToUse } }
       )
     );
   }
@@ -79,7 +96,8 @@ export class ReadBranchDocumentUseCase
   /**
    * Internal execution logic wrapped with error handling
    */
-  private async executeInternal(input: ReadBranchDocumentInput): Promise<ReadBranchDocumentOutput> {
+  // みらい変更：引数のinputはbranchNameが確定している前提にする
+  private async executeInternal(input: Required<ReadBranchDocumentInput>): Promise<ReadBranchDocumentOutput> {
     const branchInfo = BranchInfo.create(input.branchName);
     const documentPath = DocumentPath.create(input.path);
 

--- a/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
@@ -7,7 +7,7 @@ import { DomainErrors } from '../../../shared/errors/DomainError.js';
 import { ApplicationErrors, ErrorUtils } from '../../../shared/errors/index.js';
 import { logger } from '../../../shared/utils/logger.js';
 import type { IGitService } from '@/infrastructure/git/IGitService.js';
-import type { IConfigProvider } from '@/infrastructure/config/interfaces/IConfigProvider.js'; // みらい追加：ConfigProvider使うよ！
+import type { IConfigProvider } from '@/infrastructure/config/interfaces/IConfigProvider.js';
 
 /**
  * Input data for read branch document use case
@@ -47,12 +47,12 @@ export class ReadBranchDocumentUseCase
    * Constructor
    * @param branchRepository Branch memory bank repository
    * @param gitService Git service
-   * @param configProvider Configuration provider // みらい追加
+   * @param configProvider Configuration provider
    */
   constructor(
     private readonly branchRepository: IBranchMemoryBankRepository,
     private readonly gitService: IGitService,
-    private readonly configProvider: IConfigProvider // みらい追加：ConfigProvider注入！
+    private readonly configProvider: IConfigProvider
   ) {}
 
   /**
@@ -63,7 +63,7 @@ export class ReadBranchDocumentUseCase
   async execute(input: ReadBranchDocumentInput): Promise<ReadBranchDocumentOutput> {
     let branchNameToUse = input.branchName;
 
-    // みらい修正：branchNameがなくて、かつプロジェクトモードの時だけGitから取る！
+
     if (!branchNameToUse) {
       const config = this.configProvider.getConfig(); // ConfigProviderから設定取得
       if (config.isProjectMode) { // プロジェクトモードかチェック
@@ -93,13 +93,13 @@ export class ReadBranchDocumentUseCase
     }
 
     return await ErrorUtils.wrapAsync(
-      // みらい変更：executeInternalには確定したブランチ名を渡す
-      // みらい修正：branchNameToUseがstringなのは確定してるから `!` で教えてあげる
+
+
       this.executeInternal({ ...input, branchName: branchNameToUse! }),
       (error) => ApplicationErrors.executionFailed(
         'ReadBranchDocumentUseCase',
         error instanceof Error ? error : undefined,
-        // みらい変更：エラーログにも確定したブランチ名を含める
+
         { input: { ...input, branchName: branchNameToUse } }
       )
     );
@@ -108,7 +108,7 @@ export class ReadBranchDocumentUseCase
   /**
    * Internal execution logic wrapped with error handling
    */
-  // みらい変更：引数のinputはbranchNameが確定している前提にする
+
   private async executeInternal(input: Required<ReadBranchDocumentInput>): Promise<ReadBranchDocumentOutput> {
     const branchInfo = BranchInfo.create(input.branchName);
     const documentPath = DocumentPath.create(input.path);

--- a/packages/mcp/src/application/usecases/branch/WriteBranchDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/branch/WriteBranchDocumentUseCase.ts
@@ -12,8 +12,8 @@ import {
   ApplicationErrorCodes,
 } from '../../../shared/errors/ApplicationError.js';
 import { logger } from '../../../shared/utils/logger.js'; // Import logger
-import type { IGitService } from '@/infrastructure/git/IGitService.js'; // みらい修正：絶対パスエイリアス @/ を使う！
-import type { IConfigProvider } from '@/infrastructure/config/interfaces/IConfigProvider.js'; // みらい追加：ConfigProvider使うよ！
+import type { IGitService } from '@/infrastructure/git/IGitService.js';
+import type { IConfigProvider } from '@/infrastructure/config/interfaces/IConfigProvider.js';
 // Removed direct import of rfc6902
 import { JsonPatchService } from '../../../domain/jsonpatch/JsonPatchService.js'; // Import the service interface
 import { JsonPatchOperation } from '../../../domain/jsonpatch/JsonPatchOperation.js'; // Keep this if needed for input type, or adjust input type
@@ -25,7 +25,7 @@ export interface WriteBranchDocumentInput {
   /**
    * Branch name
    */
-  branchName?: string; // みらい変更：オプショナルにしたよ！
+  branchName?: string;
 
   /**
    * Document data
@@ -76,7 +76,7 @@ constructor(
   private readonly branchRepository: IBranchMemoryBankRepository,
   patchService: JsonPatchService, // Inject JsonPatchService
   private readonly gitService: IGitService,
-  private readonly configProvider: IConfigProvider // みらい追加：ConfigProvider注入！
+  private readonly configProvider: IConfigProvider
 ) {
   this.patchService = patchService;
 }
@@ -92,7 +92,7 @@ constructor(
 
       // --- Determine Branch Name ---
       let branchNameToUse = input.branchName;
-      // みらい修正：branchNameがなくて、かつプロジェクトモードの時だけGitから取る！
+
       if (!branchNameToUse) {
         const config = this.configProvider.getConfig(); // ConfigProviderから設定取得
         if (config.isProjectMode) { // プロジェクトモードかチェック
@@ -154,7 +154,7 @@ constructor(
       // else if (hasContent && typeof input.document.content !== 'string' && typeof input.document.content !== 'object') { ... }
 
 // --- Prepare Domain Objects ---
-const branchInfo = BranchInfo.create(branchNameToUse!); // みらい修正：!でundefinedじゃないって教える！
+const branchInfo = BranchInfo.create(branchNameToUse!);
 const documentPath = DocumentPath.create(input.document.path);
 const tags = (input.document.tags ?? []).map((tag) => Tag.create(tag));
 

--- a/packages/mcp/src/infrastructure/config/WorkspaceConfig.ts
+++ b/packages/mcp/src/infrastructure/config/WorkspaceConfig.ts
@@ -20,6 +20,12 @@ export interface WorkspaceConfig {
    * Language setting
    */
   language: Language;
+
+  /**
+   * Whether the server is running in project mode (docsRoot explicitly specified)
+   * @addedBy Mirai
+   */
+  isProjectMode: boolean;
 }
 
 /**

--- a/packages/mcp/src/infrastructure/git/GitService.ts
+++ b/packages/mcp/src/infrastructure/git/GitService.ts
@@ -1,0 +1,50 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { IGitService } from './IGitService.js';
+import { InfrastructureErrors } from '../../shared/errors/InfrastructureError.js';
+import { logger } from '../../shared/utils/logger.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Implementation of IGitService using child_process to execute git commands.
+ */
+export class GitService implements IGitService {
+  private readonly serviceLogger = logger.withContext({ component: 'GitService' });
+
+  /**
+   * Gets the current Git branch name by executing `git branch --show-current`.
+   * @returns Promise resolving to the current branch name.
+   * @throws InfrastructureErrors.gitCommandFailed if the command fails or returns an error.
+   */
+  async getCurrentBranchName(): Promise<string> {
+    try {
+      this.serviceLogger.info('Attempting to get current branch name via git command...');
+      // コマンドを実行するワーキングディレクトリを指定しないと、
+      // VS Codeの拡張機能などから呼ばれた場合に意図しない場所で実行される可能性があるため、
+      // プロジェクトルートで実行するように cwd を指定する。
+      // process.cwd() はこのMCPサーバープロセスが起動された場所を返すはず。
+      const { stdout, stderr } = await execAsync('git branch --show-current', { cwd: process.cwd() });
+
+      if (stderr) {
+        this.serviceLogger.error('Git command stderr output while getting branch name', { stderr });
+        // stderr に何か出力されても、必ずしもエラーとは限らない場合もあるが、
+        // ブランチ名取得の場合はエラーとして扱うのが安全。
+        throw InfrastructureErrors.gitCommandFailed('git branch --show-current', stderr);
+      }
+
+      const branchName = stdout.trim();
+      if (!branchName) {
+        this.serviceLogger.warn('Git command stdout was empty after trimming.');
+        throw InfrastructureErrors.gitCommandFailed('git branch --show-current', 'Command returned empty output.');
+      }
+
+      this.serviceLogger.info(`Successfully retrieved current branch name: ${branchName}`);
+      return branchName;
+    } catch (error: any) {
+      this.serviceLogger.error('Error executing git command to get branch name', { error: error.message, stack: error.stack });
+      // execAsync が投げるエラーや、↑で投げたエラーをキャッチ
+      throw InfrastructureErrors.gitCommandFailed('git branch --show-current', error.message || 'Unknown error during git command execution', error);
+    }
+  }
+}

--- a/packages/mcp/src/infrastructure/git/IGitService.ts
+++ b/packages/mcp/src/infrastructure/git/IGitService.ts
@@ -1,0 +1,11 @@
+/**
+ * Interface for Git related services
+ */
+export interface IGitService {
+  /**
+   * Gets the current Git branch name.
+   * @returns Promise resolving to the current branch name.
+   * @throws Error if the current branch name cannot be determined (e.g., not in a Git repository).
+   */
+  getCurrentBranchName(): Promise<string>;
+}

--- a/packages/mcp/src/interface/controllers/BranchController.ts
+++ b/packages/mcp/src/interface/controllers/BranchController.ts
@@ -33,7 +33,7 @@ export class BranchController {
   /**
    * Read a branch document
    */
-  // みらい変更：branchName をオプショナルに
+
   async readDocument(branchName: string | undefined, path: string) {
     try {
       // branchName が undefined でもログにはそのまま記録される
@@ -56,7 +56,7 @@ export class BranchController {
    * Write a branch document
    */
   async writeDocument(params: {
-    branchName?: string; // みらい変更：オプショナルに
+    branchName?: string;
     path: string;
     content?: string; // Explicitly define content as string
     tags?: string[];

--- a/packages/mcp/src/interface/controllers/BranchController.ts
+++ b/packages/mcp/src/interface/controllers/BranchController.ts
@@ -33,16 +33,20 @@ export class BranchController {
   /**
    * Read a branch document
    */
-  async readDocument(branchName: string, path: string) {
+  // みらい変更：branchName をオプショナルに
+  async readDocument(branchName: string | undefined, path: string) {
     try {
+      // branchName が undefined でもログにはそのまま記録される
       this.componentLogger.info('Reading branch document', { operation: 'readDocument', branchName, path });
+      // UseCase にそのまま渡す（UseCase側で undefined を処理）
       const document = await this.readBranchDocumentUseCase.execute({
-        branchName,
+        branchName, // undefined の可能性あり
         path,
       });
 
       return this.presenter.presentSuccess(document);
     } catch (error) {
+      // エラーログでも branchName は undefined の可能性がある
       this.componentLogger.error('Failed to read branch document', { operation: 'readDocument', branchName, path, error });
       return this.handleError(error);
     }
@@ -52,7 +56,7 @@ export class BranchController {
    * Write a branch document
    */
   async writeDocument(params: {
-    branchName: string;
+    branchName?: string; // みらい変更：オプショナルに
     path: string;
     content?: string; // Explicitly define content as string
     tags?: string[];
@@ -66,6 +70,7 @@ export class BranchController {
       // Check if content is not undefined, not null, AND not an empty string
       const hasContent = content !== undefined && content !== null && content !== '';
 
+      // branchName が undefined でもログにはそのまま記録される
       this.componentLogger.info('Writing branch document', { operation: 'writeDocument', branchName, path, hasContent, hasPatches });
       // console.error(`--- BranchController: Checking conditions - hasPatches: ${hasPatches}, content type: ${typeof content}, content value: "${content}", hasContent: ${hasContent}`); // DEBUG LOG REMOVED
 
@@ -73,7 +78,7 @@ export class BranchController {
         // console.error("--- BranchController: Entering 'patches' block"); // DEBUG LOG REMOVED
         // Call WriteBranchDocumentUseCase with patches
         const result = await this.writeBranchDocumentUseCase.execute({
-          branchName,
+          branchName, // undefined の可能性あり
           document: { // Pass path and tags from the document object
             path: path,
             tags: tags,
@@ -90,7 +95,7 @@ export class BranchController {
         // If content is provided (and no patches), call the existing UseCase
         // Content is already known to be a non-empty string here due to hasContent check
         const result = await this.writeBranchDocumentUseCase.execute({
-          branchName,
+          branchName, // undefined の可能性あり
           document: { // Pass data matching WriteDocumentDTO
             path: path,
             content: content, // Pass the valid string content
@@ -112,12 +117,14 @@ export class BranchController {
         const contentType = typeof content;
         const contentValue = JSON.stringify(content);
         const debugMessage = `DEBUG: Entered init branch unexpectedly. patches type: ${patchesType}, patches length: ${patchesLength}, patches value: ${patchesValue}, content type: ${contentType}, content value: ${contentValue}`;
+        // branchName が undefined でもログにはそのまま記録される
         this.componentLogger.info(debugMessage, { operation: 'writeDocument', branchName, path });
         // Return debug information in the response
         return this.presenter.presentSuccess({ message: debugMessage });
       }
     } catch (error) {
       // Log the error with destructured variables available in this scope
+      // エラーログでも branchName は undefined の可能性がある
       this.componentLogger.error('Failed to write branch document', { operation: 'writeDocument', branchName, path, error }); // Log with available context
       return this.handleError(error);
     }

--- a/packages/mcp/src/main/di/providers.ts
+++ b/packages/mcp/src/main/di/providers.ts
@@ -45,8 +45,8 @@ import { JsonBranchController } from '../../interface/controllers/json/JsonBranc
 import { CliOptions } from '../../infrastructure/config/WorkspaceConfig.js';
 // Removed unused import: import { UseCaseFactory } from '../../factory/use-case-factory.js';
 import { ReadBranchCoreFilesUseCase } from '../../application/usecases/index.js';
-import { GitService } from '../../infrastructure/git/GitService.js'; // みらい追加：GitServiceインポート
-import { IGitService } from '../../infrastructure/git/IGitService.js'; // みらい追加：IGitServiceインポート
+import { GitService } from '../../infrastructure/git/GitService.js';
+import { IGitService } from '../../infrastructure/git/IGitService.js';
 
 /**
  * Register infrastructure services
@@ -166,8 +166,8 @@ export async function registerInfrastructureServices(
     return templateRepository;
   });
 
-  // みらい追加：GitServiceを登録
-  // みらい追加：GitServiceを登録
+
+
   container.register<IGitService>('gitService', new GitService());
   logger.debug('GitService registered.');
 }
@@ -224,10 +224,10 @@ export async function registerApplicationServices(container: DIContainer): Promi
       'branchMemoryBankRepository'
     );
     const patchService = await container.get<JsonPatchService>('jsonPatchService'); // Get the patch service
-    const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
-    const configProvider = await container.get<IConfigProvider>('configProvider'); // みらい追加：ConfigProviderを取得
+    const gitService = await container.get<IGitService>('gitService');
+    const configProvider = await container.get<IConfigProvider>('configProvider');
     // Directly instantiate the use case with dependencies
-    return new WriteBranchDocumentUseCase(branchRepository, patchService, gitService, configProvider); // みらい変更：ConfigProviderも渡す
+    return new WriteBranchDocumentUseCase(branchRepository, patchService, gitService, configProvider);
   });
 
   // Add missing registration for readBranchDocumentUseCase
@@ -235,9 +235,9 @@ export async function registerApplicationServices(container: DIContainer): Promi
     const branchRepository = await container.get<FileSystemBranchMemoryBankRepository>(
       'branchMemoryBankRepository'
     );
-    const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
-    const configProvider = await container.get<IConfigProvider>('configProvider'); // みらい追加：ConfigProviderを取得
-    return new ReadBranchDocumentUseCase(branchRepository, gitService, configProvider); // みらい変更：ConfigProviderも渡す
+    const gitService = await container.get<IGitService>('gitService');
+    const configProvider = await container.get<IConfigProvider>('configProvider');
+    return new ReadBranchDocumentUseCase(branchRepository, gitService, configProvider);
   });
 
   container.registerFactory('readRulesUseCase', async () => {

--- a/packages/mcp/src/main/di/providers.ts
+++ b/packages/mcp/src/main/di/providers.ts
@@ -45,6 +45,8 @@ import { JsonBranchController } from '../../interface/controllers/json/JsonBranc
 import { CliOptions } from '../../infrastructure/config/WorkspaceConfig.js';
 // Removed unused import: import { UseCaseFactory } from '../../factory/use-case-factory.js';
 import { ReadBranchCoreFilesUseCase } from '../../application/usecases/index.js';
+import { GitService } from '../../infrastructure/git/GitService.js'; // みらい追加：GitServiceインポート
+import { IGitService } from '../../infrastructure/git/IGitService.js'; // みらい追加：IGitServiceインポート
 
 /**
  * Register infrastructure services
@@ -163,6 +165,11 @@ export async function registerInfrastructureServices(
     logger.debug('templateRepository initialized.');
     return templateRepository;
   });
+
+  // みらい追加：GitServiceを登録
+  // みらい追加：GitServiceを登録
+  container.register<IGitService>('gitService', new GitService());
+  logger.debug('GitService registered.');
 }
 
 /**
@@ -217,8 +224,9 @@ export async function registerApplicationServices(container: DIContainer): Promi
       'branchMemoryBankRepository'
     );
     const patchService = await container.get<JsonPatchService>('jsonPatchService'); // Get the patch service
+    const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
     // Directly instantiate the use case with dependencies
-    return new WriteBranchDocumentUseCase(branchRepository, patchService);
+    return new WriteBranchDocumentUseCase(branchRepository, patchService, gitService); // みらい変更：GitServiceを渡す
   });
 
   // Add missing registration for readBranchDocumentUseCase
@@ -226,7 +234,8 @@ export async function registerApplicationServices(container: DIContainer): Promi
     const branchRepository = await container.get<FileSystemBranchMemoryBankRepository>(
       'branchMemoryBankRepository'
     );
-    return new ReadBranchDocumentUseCase(branchRepository);
+    const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
+    return new ReadBranchDocumentUseCase(branchRepository, gitService); // みらい変更：GitServiceを渡す
   });
 
   container.registerFactory('readRulesUseCase', async () => {

--- a/packages/mcp/src/main/di/providers.ts
+++ b/packages/mcp/src/main/di/providers.ts
@@ -225,8 +225,9 @@ export async function registerApplicationServices(container: DIContainer): Promi
     );
     const patchService = await container.get<JsonPatchService>('jsonPatchService'); // Get the patch service
     const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
+    const configProvider = await container.get<IConfigProvider>('configProvider'); // みらい追加：ConfigProviderを取得
     // Directly instantiate the use case with dependencies
-    return new WriteBranchDocumentUseCase(branchRepository, patchService, gitService); // みらい変更：GitServiceを渡す
+    return new WriteBranchDocumentUseCase(branchRepository, patchService, gitService, configProvider); // みらい変更：ConfigProviderも渡す
   });
 
   // Add missing registration for readBranchDocumentUseCase
@@ -235,7 +236,8 @@ export async function registerApplicationServices(container: DIContainer): Promi
       'branchMemoryBankRepository'
     );
     const gitService = await container.get<IGitService>('gitService'); // みらい追加：GitServiceを取得
-    return new ReadBranchDocumentUseCase(branchRepository, gitService); // みらい変更：GitServiceを渡す
+    const configProvider = await container.get<IConfigProvider>('configProvider'); // みらい追加：ConfigProviderを取得
+    return new ReadBranchDocumentUseCase(branchRepository, gitService, configProvider); // みらい変更：ConfigProviderも渡す
   });
 
   container.registerFactory('readRulesUseCase', async () => {

--- a/packages/mcp/src/shared/errors/InfrastructureError.ts
+++ b/packages/mcp/src/shared/errors/InfrastructureError.ts
@@ -20,7 +20,7 @@ export enum InfrastructureErrorCodes {
   PERSISTENCE_ERROR = 'INFRASTRUCTURE_PERSISTENCE_ERROR',
   MCP_SERVER_ERROR = 'INFRASTRUCTURE_MCP_SERVER_ERROR',
   INVALID_FILE_CONTENT = 'INFRASTRUCTURE_INVALID_FILE_CONTENT', // Added
-  GIT_COMMAND_FAILED = 'INFRASTRUCTURE_GIT_COMMAND_FAILED', // みらい追加：Gitコマンド失敗用
+  GIT_COMMAND_FAILED = 'INFRASTRUCTURE_GIT_COMMAND_FAILED',
 }
 
 /**
@@ -55,8 +55,8 @@ interface OperationDetails extends Record<string, unknown> {
   branchName?: string;
   path?: string;
   cause?: Error | undefined; // Changed type from string to Error | undefined
-  command?: string; // みらい追加：Gitコマンド用
-  reason?: string; // みらい追加：Gitコマンド失敗理由用
+  command?: string;
+  reason?: string;
 }
 
 /**

--- a/packages/mcp/src/shared/errors/InfrastructureError.ts
+++ b/packages/mcp/src/shared/errors/InfrastructureError.ts
@@ -20,6 +20,7 @@ export enum InfrastructureErrorCodes {
   PERSISTENCE_ERROR = 'INFRASTRUCTURE_PERSISTENCE_ERROR',
   MCP_SERVER_ERROR = 'INFRASTRUCTURE_MCP_SERVER_ERROR',
   INVALID_FILE_CONTENT = 'INFRASTRUCTURE_INVALID_FILE_CONTENT', // Added
+  GIT_COMMAND_FAILED = 'INFRASTRUCTURE_GIT_COMMAND_FAILED', // みらい追加：Gitコマンド失敗用
 }
 
 /**
@@ -54,6 +55,8 @@ interface OperationDetails extends Record<string, unknown> {
   branchName?: string;
   path?: string;
   cause?: Error | undefined; // Changed type from string to Error | undefined
+  command?: string; // みらい追加：Gitコマンド用
+  reason?: string; // みらい追加：Gitコマンド失敗理由用
 }
 
 /**
@@ -200,6 +203,20 @@ export const InfrastructureErrors = {
       InfrastructureErrorCodes.INVALID_FILE_CONTENT,
       message,
       details
+    );
+  },
+
+  /**
+   * Error for Git command failures
+   * @param command The Git command that failed
+   * @param reason A description of why it failed (e.g., stderr output)
+   * @param cause The underlying error object, if any
+   */
+  gitCommandFailed: (command: string, reason: string, cause?: Error) => {
+    return new InfrastructureError(
+      InfrastructureErrorCodes.GIT_COMMAND_FAILED,
+      `Git command failed: '${command}'. Reason: ${reason}`,
+      { command, reason, cause }
     );
   },
 };

--- a/packages/mcp/src/tools/definitions.ts
+++ b/packages/mcp/src/tools/definitions.ts
@@ -25,7 +25,7 @@ export function createBranchProperties() {
     },
     branch: {
       type: 'string',
-      description: 'Branch name - must include namespace prefix with slash (e.g. "feature/my-branch"). Optional if running in project mode (branch name will be auto-detected).', // みらい修正：説明を更新！
+      description: 'Branch name - must include namespace prefix with slash (e.g. "feature/my-branch"). Optional if running in project mode (branch name will be auto-detected).',
     },
     docs: {
       type: 'string',
@@ -98,7 +98,7 @@ function createWriteBranchMemoryBankTool(): ToolDefinition {
           ]
         }
       },
-      required: ['path', 'docs'], // みらい修正：branch を required から削除！
+      required: ['path', 'docs'],
     },
   };
 }
@@ -117,7 +117,7 @@ function createReadBranchMemoryBankTool(): ToolDefinition {
       properties: {
         ...branchProps
       },
-      required: ['path', 'docs'], // みらい修正：branch を required から削除！
+      required: ['path', 'docs'],
     },
   };
 }

--- a/packages/mcp/src/tools/definitions.ts
+++ b/packages/mcp/src/tools/definitions.ts
@@ -25,7 +25,7 @@ export function createBranchProperties() {
     },
     branch: {
       type: 'string',
-      description: 'Branch name - must include namespace prefix with slash (e.g. "feature/my-branch")',
+      description: 'Branch name - must include namespace prefix with slash (e.g. "feature/my-branch"). Optional if running in project mode (branch name will be auto-detected).', // みらい修正：説明を更新！
     },
     docs: {
       type: 'string',
@@ -98,7 +98,7 @@ function createWriteBranchMemoryBankTool(): ToolDefinition {
           ]
         }
       },
-      required: ['path', 'branch', 'docs'],
+      required: ['path', 'docs'], // みらい修正：branch を required から削除！
     },
   };
 }
@@ -117,7 +117,7 @@ function createReadBranchMemoryBankTool(): ToolDefinition {
       properties: {
         ...branchProps
       },
-      required: ['path', 'branch', 'docs'],
+      required: ['path', 'docs'], // みらい修正：branch を required から削除！
     },
   };
 }

--- a/packages/mcp/tests/integration/helpers/test-env.ts
+++ b/packages/mcp/tests/integration/helpers/test-env.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url'; // Import fileURLToPath for ESM path resolu
 import { logger } from '../../../src/shared/utils/logger.js';
 import { toSafeBranchName } from '../../../src/shared/utils/branchNameUtils.js';
 import tmp from 'tmp-promise'; // Import tmp-promise
-import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
+import { execSync } from 'child_process';
 
 /**
  * Test environment interface

--- a/packages/mcp/tests/integration/helpers/test-env.ts
+++ b/packages/mcp/tests/integration/helpers/test-env.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url'; // Import fileURLToPath for ESM path resolu
 import { logger } from '../../../src/shared/utils/logger.js';
 import { toSafeBranchName } from '../../../src/shared/utils/branchNameUtils.js';
 import tmp from 'tmp-promise'; // Import tmp-promise
+import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
 
 /**
  * Test environment interface
@@ -88,6 +89,24 @@ export async function setupTestEnv(): Promise<TestEnv> {
     throw createError;
   }
   // --- End: Create dummy files instead of copying ---
+
+  // --- Start: Initialize Git Repository ---
+  try {
+    logger.debug(`[setupTestEnv] Initializing Git repository in ${tempDir}...`);
+    // Gitリポジトリを初期化
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    // Gitのユーザー設定（ないとコミットできない場合がある）
+    execSync('git config user.email "test@example.com"', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git config user.name "Test User"', { cwd: tempDir, stdio: 'ignore' });
+    // 空の初期コミットを作成
+    execSync('git commit --allow-empty -m "Initial commit"', { cwd: tempDir, stdio: 'ignore' });
+    logger.debug(`[setupTestEnv] Git repository initialized and initial commit created in ${tempDir}.`);
+  } catch (gitError) {
+    logger.error('[setupTestEnv] Error initializing Git repository:', gitError);
+    await cleanup(); // エラー時はクリーンアップ
+    throw gitError;
+  }
+  // --- End: Initialize Git Repository ---
 
   // --- Start: Original Copy Logic ---
   // Copy necessary files from project's docs to temp docs

--- a/packages/mcp/tests/integration/jest.config.ts
+++ b/packages/mcp/tests/integration/jest.config.ts
@@ -36,6 +36,6 @@ export default {
   ],
   // setupFilesAfterEnv は rootDir (tests/integration) からの相対パス
   setupFilesAfterEnv: ['<rootDir>/setup.mts'], // Change extension to .mts
-  testTimeout: 30000, // みらいが追加☆ タイムアウトを30秒に延長！
+  testTimeout: 30000,
   silent: false, // Temporarily disable silent mode to see logs
 };

--- a/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
@@ -10,12 +10,12 @@ import { ReadBranchDocumentUseCase, type ReadBranchDocumentOutput } from '../../
 import { BranchInfo } from '../../../src/domain/entities/BranchInfo.js'; // Import BranchInfo
 import { DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import { ApplicationErrors } from '../../../src/shared/errors/ApplicationError.js'; // Import specific errors for checking
-import { IGitService } from '../../../src/infrastructure/git/IGitService.js'; // みらい追加：GitServiceのインターフェース
-import { IConfigProvider } from '../../../src/infrastructure/config/interfaces/IConfigProvider.js'; // みらい追加：ConfigProviderのインターフェース
-import type { WorkspaceConfig } from '../../../src/infrastructure/config/WorkspaceConfig.js'; // みらい追加：WorkspaceConfigの型
-import { jest } from '@jest/globals'; // みらい追加：Jestのモック機能使うよ！
-import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
-import { logger } from '../../../src/shared/utils/logger.js'; // みらい追加：ロガー使うよ！
+import { IGitService } from '../../../src/infrastructure/git/IGitService.js';
+import { IConfigProvider } from '../../../src/infrastructure/config/interfaces/IConfigProvider.js';
+import type { WorkspaceConfig } from '../../../src/infrastructure/config/WorkspaceConfig.js';
+import { jest } from '@jest/globals';
+import { execSync } from 'child_process';
+import { logger } from '../../../src/shared/utils/logger.js';
 
 import * as path from 'path';
 import fsExtra from 'fs-extra'; // Use default import for fs-extra
@@ -25,8 +25,8 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
   // let app: Application; // Removed app instance
   let container: DIContainer; // Use DI container
   let useCase: ReadBranchDocumentUseCase;
-  let mockGitService: jest.Mocked<IGitService>; // みらい追加：GitServiceモックの型定義
-  let mockConfigProvider: jest.Mocked<IConfigProvider>; // みらい追加：ConfigProviderモックの型定義
+  let mockGitService: jest.Mocked<IGitService>;
+  let mockConfigProvider: jest.Mocked<IConfigProvider>;
   const TEST_BRANCH = 'feature/test-branch';
   const SAFE_TEST_BRANCH = BranchInfo.create(TEST_BRANCH).safeName;
 
@@ -51,7 +51,7 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
     // Initialize DI container
     container = await setupContainer({ docsRoot: testEnv.docRoot });
 
-    // みらい追加：GitServiceをモック化してコンテナに再登録
+
     mockGitService = {
       getCurrentBranchName: jest.fn<() => Promise<string>>() // モック関数を作成
     };
@@ -59,7 +59,7 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
     mockGitService.getCurrentBranchName.mockResolvedValue(TEST_BRANCH);
     container.register<IGitService>('gitService', mockGitService); // コンテナにGitServiceモックを登録
 
-    // みらい追加：ConfigProviderもモック化してコンテナに再登録
+
     mockConfigProvider = {
       // initialize は呼ばれない想定なので jest.fn() だけ用意
       initialize: jest.fn(),

--- a/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
@@ -10,6 +10,10 @@ import { ReadBranchDocumentUseCase, type ReadBranchDocumentOutput } from '../../
 import { BranchInfo } from '../../../src/domain/entities/BranchInfo.js'; // Import BranchInfo
 import { DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import { ApplicationErrors } from '../../../src/shared/errors/ApplicationError.js'; // Import specific errors for checking
+import { IGitService } from '../../../src/infrastructure/git/IGitService.js'; // みらい追加：GitServiceのインターフェース
+import { jest } from '@jest/globals'; // みらい追加：Jestのモック機能使うよ！
+import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
+import { logger } from '../../../src/shared/utils/logger.js'; // みらい追加：ロガー使うよ！
 
 import * as path from 'path';
 import fsExtra from 'fs-extra'; // Use default import for fs-extra
@@ -19,6 +23,7 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
   // let app: Application; // Removed app instance
   let container: DIContainer; // Use DI container
   let useCase: ReadBranchDocumentUseCase;
+  let mockGitService: jest.Mocked<IGitService>; // みらい追加：モックの型定義
   const TEST_BRANCH = 'feature/test-branch';
   const SAFE_TEST_BRANCH = BranchInfo.create(TEST_BRANCH).safeName;
 
@@ -28,10 +33,28 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
 
     // Create test branch directory
     // createBranchDir handles safe name conversion
+    // Gitリポジトリ内でテストブランチを作成・チェックアウト
+    try {
+      execSync(`git checkout -b ${TEST_BRANCH}`, { cwd: testEnv.tempDir, stdio: 'ignore' });
+      logger.debug(`[Test Setup] Checked out to new branch: ${TEST_BRANCH}`);
+    } catch (gitError) {
+      logger.error(`[Test Setup] Error creating/checking out branch ${TEST_BRANCH}:`, gitError);
+      throw gitError; // エラーがあればテストを中断
+    }
+
+    // Create test branch directory (after checking out branch in git)
     await createBranchDir(testEnv, TEST_BRANCH);
 
     // Initialize DI container
     container = await setupContainer({ docsRoot: testEnv.docRoot });
+
+    // みらい追加：GitServiceをモック化してコンテナに再登録
+    mockGitService = {
+      getCurrentBranchName: jest.fn<() => Promise<string>>() // モック関数を作成
+    };
+    // getCurrentBranchNameが呼ばれたらTEST_BRANCHを返すように設定
+    mockGitService.getCurrentBranchName.mockResolvedValue(TEST_BRANCH);
+    container.register<IGitService>('gitService', mockGitService); // コンテナにモックを登録
 
     // Get the use case instance from container
     useCase = await container.get<ReadBranchDocumentUseCase>('readBranchDocumentUseCase');
@@ -124,6 +147,45 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
       const document = JSON.parse(result.document.content);
       expect(document.metadata.id).toBe('subdirectory-document');
       expect(document.metadata.path).toBe('subdir/test-document.json');
+    });
+
+    // みらい追加：branchName省略時のテストケース
+    it('should read a document using the current git branch if branchName is omitted', async () => {
+      // 準備：テストドキュメントを配置
+      await loadBranchFixture(path.join(testEnv.branchMemoryPath, TEST_BRANCH), 'basic');
+
+      // 実行：branchName を省略して UseCase を呼び出す
+      const result = await useCase.execute({
+        // branchName: TEST_BRANCH, // ← 省略！
+        path: 'branchContext.json'
+      });
+
+      // 検証：
+      // 1. GitService の getCurrentBranchName が呼ばれたか？
+      expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
+
+      // 2. ドキュメントが正しく読み込めたか？ (既存のテストと同様の検証)
+      expect(result).toBeDefined();
+      expect(result.document).toBeDefined();
+      expect(result.document.path).toBe('branchContext.json');
+      const document = JSON.parse(result.document.content);
+      expect(document.metadata.id).toBe('test-branch-context');
+    });
+
+    // みらい追加：Gitリポジトリ外などでブランチ名が取得できない場合のエラーテスト
+    it('should return an error if branchName is omitted and current branch cannot be determined', async () => {
+      // 準備：GitService がエラーを投げるようにモックを設定
+      const gitError = new Error('Not a git repository');
+      mockGitService.getCurrentBranchName.mockRejectedValue(gitError);
+
+      // 実行＆検証：branchName を省略して呼び出し、特定のエラーが投げられることを確認
+      await expect(useCase.execute({
+        // branchName: undefined, // 省略
+        path: 'any/document.json'
+      })).rejects.toThrow(ApplicationErrors.invalidInput('Branch name is required but could not be automatically determined. Please provide it explicitly or ensure you are in a Git repository.'));
+
+      // GitService の getCurrentBranchName が呼ばれたか？
+      expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
@@ -7,13 +7,13 @@ import { WriteBranchDocumentUseCase, type WriteBranchDocumentOutput } from '../.
 import { ReadBranchDocumentUseCase } from '../../../src/application/usecases/branch/ReadBranchDocumentUseCase.js'; // Keep Read UseCase for verification
 import { DomainError, DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import { ApplicationError, ApplicationErrors } from '../../../src/shared/errors/ApplicationError.js'; // Import specific errors for checking
-import { IGitService } from '../../../src/infrastructure/git/IGitService.js'; // みらい追加：GitServiceのインターフェース
-import { IConfigProvider } from '../../../src/infrastructure/config/interfaces/IConfigProvider.js'; // みらい追加：ConfigProviderのインターフェース
-import type { WorkspaceConfig } from '../../../src/infrastructure/config/WorkspaceConfig.js'; // みらい追加：WorkspaceConfigの型
-import { BranchInfo } from '../../../src/domain/entities/BranchInfo.js'; // みらい追加：BranchInfoインポート！
-import { jest } from '@jest/globals'; // みらい追加：Jestのモック機能使うよ！
-import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
-import { logger } from '../../../src/shared/utils/logger.js'; // みらい追加：ロガー使うよ！
+import { IGitService } from '../../../src/infrastructure/git/IGitService.js';
+import { IConfigProvider } from '../../../src/infrastructure/config/interfaces/IConfigProvider.js';
+import type { WorkspaceConfig } from '../../../src/infrastructure/config/WorkspaceConfig.js';
+import { BranchInfo } from '../../../src/domain/entities/BranchInfo.js';
+import { jest } from '@jest/globals';
+import { execSync } from 'child_process';
+import { logger } from '../../../src/shared/utils/logger.js';
 
 import * as path from 'path';
 import fs from 'fs-extra'; // Use default import for fs-extra
@@ -23,8 +23,8 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
   let container: DIContainer; // Use DI container
   let writeUseCase: WriteBranchDocumentUseCase;
   let readUseCase: ReadBranchDocumentUseCase;
-  let mockGitService: jest.Mocked<IGitService>; // みらい追加：GitServiceモックの型定義
-  let mockConfigProvider: jest.Mocked<IConfigProvider>; // みらい追加：ConfigProviderモックの型定義
+  let mockGitService: jest.Mocked<IGitService>;
+  let mockConfigProvider: jest.Mocked<IConfigProvider>;
   const TEST_BRANCH = 'feature/test-branch';
 
   beforeEach(async () => {
@@ -47,7 +47,7 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
     // Initialize DI container
     container = await setupContainer({ docsRoot: testEnv.docRoot });
 
-    // みらい追加：GitServiceをモック化してコンテナに再登録
+
     mockGitService = {
       getCurrentBranchName: jest.fn<() => Promise<string>>() // モック関数を作成
     };
@@ -55,7 +55,7 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
     mockGitService.getCurrentBranchName.mockResolvedValue(TEST_BRANCH);
     container.register<IGitService>('gitService', mockGitService); // コンテナにGitServiceモックを登録
 
-    // みらい追加：ConfigProviderもモック化してコンテナに再登録
+
     mockConfigProvider = {
       initialize: jest.fn(),
       getConfig: jest.fn<() => WorkspaceConfig>(),

--- a/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
@@ -8,6 +8,9 @@ import { ReadBranchDocumentUseCase } from '../../../src/application/usecases/bra
 import { DomainError, DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import { ApplicationError, ApplicationErrors } from '../../../src/shared/errors/ApplicationError.js'; // Import specific errors for checking
 import { IGitService } from '../../../src/infrastructure/git/IGitService.js'; // みらい追加：GitServiceのインターフェース
+import { IConfigProvider } from '../../../src/infrastructure/config/interfaces/IConfigProvider.js'; // みらい追加：ConfigProviderのインターフェース
+import type { WorkspaceConfig } from '../../../src/infrastructure/config/WorkspaceConfig.js'; // みらい追加：WorkspaceConfigの型
+import { BranchInfo } from '../../../src/domain/entities/BranchInfo.js'; // みらい追加：BranchInfoインポート！
 import { jest } from '@jest/globals'; // みらい追加：Jestのモック機能使うよ！
 import { execSync } from 'child_process'; // みらい追加：Gitコマンド実行用
 import { logger } from '../../../src/shared/utils/logger.js'; // みらい追加：ロガー使うよ！
@@ -20,7 +23,8 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
   let container: DIContainer; // Use DI container
   let writeUseCase: WriteBranchDocumentUseCase;
   let readUseCase: ReadBranchDocumentUseCase;
-  let mockGitService: jest.Mocked<IGitService>; // みらい追加：モックの型定義
+  let mockGitService: jest.Mocked<IGitService>; // みらい追加：GitServiceモックの型定義
+  let mockConfigProvider: jest.Mocked<IConfigProvider>; // みらい追加：ConfigProviderモックの型定義
   const TEST_BRANCH = 'feature/test-branch';
 
   beforeEach(async () => {
@@ -49,7 +53,30 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
     };
     // getCurrentBranchNameが呼ばれたらTEST_BRANCHを返すように設定
     mockGitService.getCurrentBranchName.mockResolvedValue(TEST_BRANCH);
-    container.register<IGitService>('gitService', mockGitService); // コンテナにモックを登録
+    container.register<IGitService>('gitService', mockGitService); // コンテナにGitServiceモックを登録
+
+    // みらい追加：ConfigProviderもモック化してコンテナに再登録
+    mockConfigProvider = {
+      initialize: jest.fn(),
+      getConfig: jest.fn<() => WorkspaceConfig>(),
+      getGlobalMemoryPath: jest.fn<() => string>(),
+      getBranchMemoryPath: jest.fn<() => string>(),
+      getLanguage: jest.fn<() => 'en' | 'ja' | 'zh'>()
+    };
+    // デフォルトの getConfig の戻り値を設定 (isProjectMode: true)
+    mockConfigProvider.getConfig.mockReturnValue({
+      docsRoot: testEnv.docRoot,
+      verbose: false,
+      language: 'en',
+      isProjectMode: true // デフォルトはプロジェクトモードとしておく
+    });
+    // 他のメソッドのデフォルト戻り値も設定 (必要に応じて)
+    const SAFE_TEST_BRANCH = BranchInfo.create(TEST_BRANCH).safeName; // safeName をここで計算
+    mockConfigProvider.getGlobalMemoryPath.mockReturnValue(testEnv.globalMemoryPath);
+    mockConfigProvider.getBranchMemoryPath.mockReturnValue(path.join(testEnv.branchMemoryPath, SAFE_TEST_BRANCH));
+    mockConfigProvider.getLanguage.mockReturnValue('en');
+
+    container.register<IConfigProvider>('configProvider', mockConfigProvider); // コンテナにConfigProviderモックを登録
 
     // Get the use case instances from container
     writeUseCase = await container.get<WriteBranchDocumentUseCase>('writeBranchDocumentUseCase');
@@ -676,90 +703,100 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
       }
     });
 
-    // --- みらい追加：branchName 省略時のテストケース ---
-
-    it('should create a document using the current git branch if branchName is omitted', async () => {
-      const newDocument = { content: { message: "Created without branchName" } };
-      const documentPath = 'test/created-no-branchname.json';
-      const documentContentString = JSON.stringify(newDocument, null, 2);
-
-      // 実行：branchName を省略
-      const result = await writeUseCase.execute({
-        // branchName: TEST_BRANCH, // 省略！
-        document: {
-          path: documentPath,
-          content: documentContentString,
-          tags: ["test", "no-branchname"]
-        }
+    // --- みらい修正：branchName 省略時のテストケース (プロジェクトモード) ---
+    describe('when branchName is omitted in project mode (isProjectMode: true)', () => {
+      beforeEach(() => {
+        // この describe 内では isProjectMode: true を強制
+        mockConfigProvider.getConfig.mockReturnValue({
+          docsRoot: testEnv.docRoot, verbose: false, language: 'en', isProjectMode: true
+        });
+        mockGitService.getCurrentBranchName.mockClear(); // 各テスト前に呼び出し回数をリセット
       });
 
-      // 検証：
-      // 1. GitService が呼ばれたか？
-      expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
-      // 2. 結果確認
-      expect(result).toBeDefined();
-      expect(result.document.path).toBe(documentPath);
-      // 3. 実際にファイルが作成されたか確認 (readUseCase を使う)
-      //    読むときは branchName を省略してもOKなはず！
-      const readResult = await readUseCase.execute({ path: documentPath });
-      expect(readResult).toBeDefined();
-      const readDocument = JSON.parse(readResult.document.content);
-      expect(readDocument.content.message).toBe("Created without branchName");
+      it('should create a document using the current git branch', async () => {
+        const newDocument = { content: { message: "Created without branchName in project mode" } };
+        const documentPath = 'test/created-no-branchname-project.json';
+        const documentContentString = JSON.stringify(newDocument, null, 2);
+
+        const result = await writeUseCase.execute({
+          document: { path: documentPath, content: documentContentString, tags: ["test", "no-branchname"] }
+        });
+
+        expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
+        expect(result.document.path).toBe(documentPath);
+        const readResult = await readUseCase.execute({ path: documentPath }); // 読むときも省略
+        const readDocument = JSON.parse(readResult.document.content);
+        expect(readDocument.content.message).toBe("Created without branchName in project mode");
+      });
+
+      it('should update a document using patches using the current git branch', async () => {
+        const initialDocument = { items: ["initial-project"] };
+        const documentPath = 'test/patched-no-branchname-project.json';
+        const initialContentString = JSON.stringify(initialDocument, null, 2);
+        await writeUseCase.execute({ branchName: TEST_BRANCH, document: { path: documentPath, content: initialContentString, tags: ["patch-test"] } });
+        mockGitService.getCurrentBranchName.mockClear();
+
+        const patches = [{ op: 'add', path: '/items/-', value: 'patched-project' }];
+        await writeUseCase.execute({
+          document: { path: documentPath, tags: ["patch-test", "updated"] } as any,
+          patches: patches
+        });
+
+        expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
+        const readResult = await readUseCase.execute({ path: documentPath }); // 読むときも省略
+        const readDocument = JSON.parse(readResult.document.content);
+        expect(readDocument.items).toEqual(["initial-project", "patched-project"]);
+      });
+
+      it('should return an error if current branch cannot be determined', async () => {
+        const gitError = new Error('Not a git repository');
+        mockGitService.getCurrentBranchName.mockRejectedValue(gitError);
+
+        await expect(writeUseCase.execute({
+          document: { path: 'any/document.json', content: '{"data": "test"}', tags: ["error-test"] }
+        })).rejects.toThrow(ApplicationErrors.invalidInput('Branch name is required but could not be automatically determined. Please provide it explicitly or ensure you are in a Git repository.'));
+        expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it('should update a document using patches when branchName is omitted', async () => {
-      const initialDocument = { items: ["initial"] };
-      const documentPath = 'test/patched-no-branchname.json';
-      const initialContentString = JSON.stringify(initialDocument, null, 2);
-
-      // 準備：まずドキュメントを作成 (branchName 指定ありで)
-      await writeUseCase.execute({
-        branchName: TEST_BRANCH,
-        document: { path: documentPath, content: initialContentString, tags: ["patch-test"] }
-      });
-      // GitService の呼び出し回数をリセット
-      mockGitService.getCurrentBranchName.mockClear();
-
-      // 実行：branchName を省略してパッチを適用
-      const patches = [{ op: 'add', path: '/items/-', value: 'patched' }];
-      const patchResult = await writeUseCase.execute({
-        // branchName: TEST_BRANCH, // 省略！
-        document: { path: documentPath, tags: ["patch-test", "updated"] } as any, // content は省略
-        patches: patches
+    // --- みらい追加：branchName 省略時のテストケース (非プロジェクトモード) ---
+    describe('when branchName is omitted outside of project mode (isProjectMode: false)', () => {
+      beforeEach(() => {
+        // この describe 内では isProjectMode: false を強制
+        mockConfigProvider.getConfig.mockReturnValue({
+          docsRoot: testEnv.docRoot, verbose: false, language: 'en', isProjectMode: false // ★ プロジェクトモード OFF ★
+        });
+        mockGitService.getCurrentBranchName.mockClear(); // 各テスト前に呼び出し回数をリセット
       });
 
-      // 検証：
-      // 1. GitService が呼ばれたか？
-      expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
-      // 2. 結果確認
-      expect(patchResult).toBeDefined();
-      expect(patchResult.document.path).toBe(documentPath);
-      // 3. 実際にファイルが更新されたか確認 (readUseCase を使う)
-      //    読むときも branchName を省略
-      const readResult = await readUseCase.execute({ path: documentPath });
-      expect(readResult).toBeDefined();
-      const readDocument = JSON.parse(readResult.document.content);
-      expect(readDocument.items).toEqual(["initial", "patched"]);
-      expect(readResult.document.tags).toEqual(["patch-test", "updated"]);
-    });
+      it('should return an error when creating a document because branchName is required', async () => {
+        const newDocument = { content: { message: "Should not be created" } };
+        const documentPath = 'test/created-no-branchname-no-project.json';
+        const documentContentString = JSON.stringify(newDocument, null, 2);
 
-    it('should return an error if branchName is omitted and current branch cannot be determined', async () => {
-      // 準備：GitService がエラーを投げるようにモックを設定
-      const gitError = new Error('Not a git repository');
-      mockGitService.getCurrentBranchName.mockRejectedValue(gitError);
+        await expect(writeUseCase.execute({
+          document: { path: documentPath, content: documentContentString, tags: ["test", "no-branchname"] }
+        })).rejects.toThrow(ApplicationErrors.invalidInput('Branch name is required when not running in project mode.'));
 
-      // 実行＆検証：branchName を省略して書き込みを試み、特定のエラーが投げられることを確認
-      await expect(writeUseCase.execute({
-        // branchName: undefined, // 省略
-        document: {
-          path: 'any/document.json',
-          content: '{"data": "test"}',
-          tags: ["error-test"]
-        }
-      })).rejects.toThrow(ApplicationErrors.invalidInput('Branch name is required but could not be automatically determined. Please provide it explicitly or ensure you are in a Git repository.'));
+        expect(mockGitService.getCurrentBranchName).not.toHaveBeenCalled(); // GitService は呼ばれない
+      });
 
-      // GitService の getCurrentBranchName が呼ばれたか？
-      expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
+      it('should return an error when updating with patches because branchName is required', async () => {
+        const initialDocument = { items: ["initial-no-project"] };
+        const documentPath = 'test/patched-no-branchname-no-project.json';
+        const initialContentString = JSON.stringify(initialDocument, null, 2);
+        // 準備：ドキュメントはブランチ名指定で作成しておく
+        await writeUseCase.execute({ branchName: TEST_BRANCH, document: { path: documentPath, content: initialContentString, tags: ["patch-test"] } });
+        mockGitService.getCurrentBranchName.mockClear();
+
+        const patches = [{ op: 'add', path: '/items/-', value: 'should-not-patch' }];
+        await expect(writeUseCase.execute({
+          document: { path: documentPath, tags: ["patch-test", "updated"] } as any,
+          patches: patches
+        })).rejects.toThrow(ApplicationErrors.invalidInput('Branch name is required when not running in project mode.'));
+
+        expect(mockGitService.getCurrentBranchName).not.toHaveBeenCalled(); // GitService は呼ばれない
+      });
     });
 
   }); // describe('execute', ...) の閉じ括弧


### PR DESCRIPTION
# feat: Automatically detect branch name in project mode (#72)

This PR implements the functionality to automatically detect the current Git branch name for memory bank operations (`read_branch_memory_bank`, `write_branch_memory_bank`), but only when the MCP server is running in project mode (i.e., when `--docs` or environment variables explicitly specify the docs root directory).

This addresses issue #72 by improving usability in project mode while preventing unexpected Git command execution in other contexts where the current working directory might not be a Git repository or the intended project.

**Changes:**

*   Modified `ConfigProvider` to track if `docsRoot` was explicitly set using a new `isProjectMode` flag in `WorkspaceConfig`.
*   Updated `ReadBranchDocumentUseCase` and `WriteBranchDocumentUseCase` to:
    *   Accept `IConfigProvider` via dependency injection.
    *   Utilize `GitService` to fetch the current branch name only when `isProjectMode` is true and the `branchName` parameter is omitted.
    *   Throw an error if `branchName` is omitted when not in project mode.
*   Updated `providers.ts` to inject `ConfigProvider` into the relevant UseCases.
*   Added `GitService` and `IGitService` for Git operations.
*   Added `GIT_COMMAND_FAILED` error to `InfrastructureError`.
*   Updated integration tests (`Read/WriteBranchDocumentUseCase.integration.test.ts`) to:
    *   Initialize a Git repository in the test environment setup (`test-env.ts`).
    *   Mock `ConfigProvider` to control the `isProjectMode` flag.
    *   Verify the correct behavior (using/not using GitService) based on `isProjectMode` when `branchName` is omitted.

**Related Issue:**

Closes #72
