### PR TITLE
Refactor Logger Usage

### DIFF
--- a/docs/branch-memory-bank/fix-supress-logs/activeContext.json
+++ b/docs/branch-memory-bank/fix-supress-logs/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-supress-logs-active-context",
+    "title": "Active Context for fix/supress-logs",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T03:01:53.571Z",
+    "lastModified": "2025-04-04T03:01:53.571Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: fix/supress-logs",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/branch-memory-bank/fix-supress-logs/branchContext.json
+++ b/docs/branch-memory-bank/fix-supress-logs/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-supress-logs-context",
+    "title": "Branch Context for fix/supress-logs",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T03:01:53.571Z",
+    "lastModified": "2025-04-04T03:01:53.571Z"
+  },
+  "content": {
+    "description": "Context for branch: fix/supress-logs"
+  }
+}

--- a/docs/branch-memory-bank/fix-supress-logs/progress.json
+++ b/docs/branch-memory-bank/fix-supress-logs/progress.json
@@ -1,0 +1,57 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-supress-logs-progress",
+    "title": "Progress for fix/supress-logs",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-04T03:01:53.571Z",
+    "lastModified": "2025-04-04T03:32:59.561Z"
+  },
+  "content": {
+    "summary": "ロガー利用方針に基づき実装を完了し、コミットした。",
+    "status": "implementation_completed",
+    "steps": [
+      {
+        "id": "define_logger_policy",
+        "description": "ロガー利用方針を定義した。",
+        "status": "done",
+        "details": {
+          "policy": [
+            "標準ロガーへの移行: console.* を直接使わず、標準ロガー経由で出力。stderr への直接出力は避ける。",
+            "ログレベル定義: DEBUG, INFO, WARN, ERROR を定義し使い分ける。",
+            "console.* の扱い: 一時利用はOK、コミット前に整理。",
+            "本番ログ制御: 環境変数等でレベル制御、本番デフォルトは INFO。",
+            "構造化ロギング (JSON): ログは必ず JSON 形式で出力。",
+            "デバッグログ整理: テスト中の console.* を整理するタスクを追加。"
+          ]
+        }
+      },
+      {
+        "id": "implement_logger_policy",
+        "description": "定義したロガー方針に基づき実装（標準ロガー整備、既存ログ整理）を行い、コミットした。",
+        "status": "done"
+      }
+    ],
+    "next_steps": [
+      {
+        "id": "finalize_work",
+        "description": "DesignGuru モードに戻り、PR作成などの後処理を行う。",
+        "status": "todo"
+      }
+    ],
+    "findings": [
+      {
+        "id": "json_rpc_consideration",
+        "description": "標準入出力での JSON-RPC 通信のため、stderr への直接ログ出力は避け、ログは JSON 形式でシリアライズする必要がある。",
+        "source": "user_feedback"
+      },
+      {
+        "id": "debug_log_cleanup_needed",
+        "description": "テスト中に追加されたデバッグログの整理が必要。",
+        "source": "user_feedback"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/fix-supress-logs/systemPatterns.json
+++ b/docs/branch-memory-bank/fix-supress-logs/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-supress-logs-system-patterns",
+    "title": "System Patterns for fix/supress-logs",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T03:01:53.571Z",
+    "lastModified": "2025-04-04T03:01:53.571Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/packages/mcp/src/application/i18n/I18nService.ts
+++ b/packages/mcp/src/application/i18n/I18nService.ts
@@ -7,6 +7,7 @@
 import { Language, LanguageCode } from '../../domain/i18n/Language.js';
 import { II18nRepository } from '../../domain/i18n/II18nRepository.js';
 import { Translation } from '../../domain/i18n/Translation.js';
+import { logger } from '../../shared/utils/logger.js'; // みらい: logger をインポート
 
 /**
  * Service for handling internationalization and translations
@@ -103,7 +104,7 @@ export class I18nService {
       const languageCode = secondParam;
 
       if (!this.isTranslationLoaded) {
-        console.warn('Translations not loaded. Call loadAllTranslations() first.');
+        logger.warn('Translations not loaded. Call loadAllTranslations() first.', { component: 'I18nService' }); // みらい: console.warn を logger.warn に変更
         return `?${key}`;
       }
 

--- a/packages/mcp/src/infrastructure/i18n/I18nProvider.ts
+++ b/packages/mcp/src/infrastructure/i18n/I18nProvider.ts
@@ -45,8 +45,9 @@ export class I18nProvider implements II18nProvider {
     let language = langParam; // Declare language with let for reassignment
 
     if (!this.translations.has(language)) {
-      console.warn(
-        `Translations not loaded for language ${language}, falling back to ${this.defaultLanguage}`
+      logger.warn( // みらい: console.warn を logger.warn に変更
+        `Translations not loaded for language ${language}, falling back to ${this.defaultLanguage}`,
+        { component: 'I18nProvider', language }
       );
 
       if (!this.translations.has(this.defaultLanguage)) {
@@ -87,7 +88,7 @@ export class I18nProvider implements II18nProvider {
 
       const exists = await this.fileSystemService.fileExists(filePath);
       if (!exists) {
-        console.warn(`Translation file not found: ${filePath}`);
+        logger.warn(`Translation file not found: ${filePath}`, { component: 'I18nProvider', filePath }); // みらい: console.warn を logger.warn に変更
         return false;
       }
 
@@ -95,8 +96,9 @@ export class I18nProvider implements II18nProvider {
       const translationFile = JSON.parse(content) as TranslationFile;
 
       if (translationFile.language !== language) {
-        console.warn(
-          `Language mismatch in translation file: expected ${language}, got ${translationFile.language}`
+        logger.warn( // みらい: console.warn を logger.warn に変更
+          `Language mismatch in translation file: expected ${language}, got ${translationFile.language}`,
+          { component: 'I18nProvider', filePath, expectedLanguage: language, actualLanguage: translationFile.language }
         );
         return false;
       }

--- a/packages/mcp/src/infrastructure/logger/LoggerFactory.ts
+++ b/packages/mcp/src/infrastructure/logger/LoggerFactory.ts
@@ -33,7 +33,7 @@ export class LoggerFactory {
   private loggers: Map<string, Logger> = new Map();
 
   private constructor() {
-    console.warn('[DEPRECATED] LoggerFactory is deprecated. Use shared/utils/logger.ts instead.');
+    logger.warn('[DEPRECATED] LoggerFactory is deprecated. Use shared/utils/logger.ts instead.', { component: 'LoggerFactory' }); // みらい: console.warn を logger.warn に変更
   }
 
   /**
@@ -53,7 +53,7 @@ export class LoggerFactory {
    * @deprecated Use createConsoleLogger from shared/utils/logger.ts instead.
    */
   public createLogger(options: LoggerFactoryOptions): Logger {
-    console.warn('[DEPRECATED] LoggerFactory.createLogger is deprecated. Use shared/utils/logger.ts instead.');
+    logger.warn('[DEPRECATED] LoggerFactory.createLogger is deprecated. Use shared/utils/logger.ts instead.', { component: 'LoggerFactory' }); // みらい: console.warn を logger.warn に変更
 
     const { minLevel = 'info', defaultContext } = options;
     let newLogger: Logger;
@@ -75,7 +75,7 @@ export class LoggerFactory {
    * @deprecated Use logger.withContext({ component: name }) from shared/utils/logger.ts instead.
    */
   public getLogger(name: string, options: LoggerFactoryOptions): Logger {
-    console.warn('[DEPRECATED] LoggerFactory.getLogger is deprecated. Use logger.withContext({ component: name }) instead.');
+    logger.warn('[DEPRECATED] LoggerFactory.getLogger is deprecated. Use logger.withContext({ component: name }) instead.', { component: 'LoggerFactory', loggerName: name }); // みらい: console.warn を logger.warn に変更
 
     if (this.loggers.has(name)) {
       return this.loggers.get(name)!;
@@ -92,7 +92,7 @@ export class LoggerFactory {
    * @deprecated Use the 'logger' export from shared/utils/logger.ts instead.
    */
   public static getDefaultLogger(): Logger {
-    console.warn('[DEPRECATED] LoggerFactory.getDefaultLogger is deprecated. Use the \'logger\' export from shared/utils/logger.ts instead.');
+    logger.warn('[DEPRECATED] LoggerFactory.getDefaultLogger is deprecated. Use the \'logger\' export from shared/utils/logger.ts instead.', { component: 'LoggerFactory' }); // みらい: console.warn を logger.warn に変更
     return LoggerFactory.getInstance().getLogger('default', {
       type: LoggerType.CONSOLE,
       minLevel: 'info'
@@ -105,7 +105,7 @@ export class LoggerFactory {
    * @deprecated Use direct imports from shared/utils/logger.ts instead.
    */
   public clear(): void {
-    console.warn('[DEPRECATED] LoggerFactory.clear is deprecated.');
+    logger.warn('[DEPRECATED] LoggerFactory.clear is deprecated.', { component: 'LoggerFactory' }); // みらい: console.warn を logger.warn に変更
     this.loggers.clear();
   }
 }

--- a/packages/mcp/src/infrastructure/templates/JsonTemplateLoader.ts
+++ b/packages/mcp/src/infrastructure/templates/JsonTemplateLoader.ts
@@ -11,6 +11,7 @@ import { IFileSystemService } from '../storage/interfaces/IFileSystemService.js'
 import { II18nProvider } from '../i18n/interfaces/II18nProvider.js';
 import { TemplateRenderer } from './TeplateRenderer.js';
 import { ITemplateLoader } from './interfaces/ITemplateLoader.js';
+import { logger } from '../../shared/utils/logger.js'; // みらい: logger をインポート
 
 /**
  * Implementation of ITemplateLoader for JSON templates
@@ -102,8 +103,9 @@ export class JsonTemplateLoader implements ITemplateLoader {
         (error as Error).message.includes('Template not found') ||
         (error as Error).message.includes('Invalid JSON')
       ) {
-        console.warn(
-          `JSON template ${templateId} not found or invalid, falling back to legacy template..`
+        logger.warn( // みらい: console.warn を logger.warn に変更
+          `JSON template ${templateId} not found or invalid, falling back to legacy template..`,
+          { component: 'JsonTemplateLoader', templateId }
         );
 
         try {

--- a/packages/mcp/src/interface/controllers/BranchController.ts
+++ b/packages/mcp/src/interface/controllers/BranchController.ts
@@ -72,10 +72,10 @@ export class BranchController {
 
       // branchName が undefined でもログにはそのまま記録される
       this.componentLogger.info('Writing branch document', { operation: 'writeDocument', branchName, path, hasContent, hasPatches });
-      // console.error(`--- BranchController: Checking conditions - hasPatches: ${hasPatches}, content type: ${typeof content}, content value: "${content}", hasContent: ${hasContent}`); // DEBUG LOG REMOVED
+      // みらい: 不要なデバッグログを削除
 
       if (hasPatches) {
-        // console.error("--- BranchController: Entering 'patches' block"); // DEBUG LOG REMOVED
+        // みらい: 不要なデバッグログを削除
         // Call WriteBranchDocumentUseCase with patches
         const result = await this.writeBranchDocumentUseCase.execute({
           branchName, // undefined の可能性あり
@@ -87,11 +87,10 @@ export class BranchController {
           patches: patches // Pass the patches array
         });
         // Log the result from the use case and the data being presented
-        // console.error("--- BranchController: UseCase result:", JSON.stringify(result, null, 2)); // DEBUG LOG REMOVED
-        // console.error("--- BranchController: Presenting data:", JSON.stringify(result.document, null, 2)); // DEBUG LOG REMOVED
+        // みらい: 不要なデバッグログを削除
        return this.presenter.presentSuccess(result.document);
       } else if (hasContent) {
-        // console.error("--- BranchController: Entering 'content' block"); // DEBUG LOG REMOVED
+        // みらい: 不要なデバッグログを削除
         // If content is provided (and no patches), call the existing UseCase
         // Content is already known to be a non-empty string here due to hasContent check
         const result = await this.writeBranchDocumentUseCase.execute({
@@ -106,7 +105,7 @@ export class BranchController {
          // Return the document DTO directly from the use case result
         return this.presenter.presentSuccess(result.document);
       } else {
-        // console.error("--- BranchController: Entering 'else' (init) block"); // DEBUG LOG REMOVED
+        // みらい: 不要なデバッグログを削除
         // Handle the case where neither content nor patches are provided (or patches is an empty array)
         // This might need a dedicated initialization UseCase or logic.
         // For now, return the initialization message similar to routes.ts logic.

--- a/packages/mcp/src/shared/utils/logger.ts
+++ b/packages/mcp/src/shared/utils/logger.ts
@@ -146,9 +146,7 @@ export function createConsoleLogger(level: LogLevel = 'info'): Logger {
   /**
    * Format the log entry with level prefix and timestamp
    */
-  function formatLogEntry(level: LogLevel, message: string): string {
-    return `[${level.toUpperCase()}] ${message}`;
-  }
+  // Removed: formatLogEntry as we now output JSON
 
   /**
    * Prepare context with defaults and auto-populated fields
@@ -165,45 +163,73 @@ export function createConsoleLogger(level: LogLevel = 'info'): Logger {
   const logger: Logger = {
     debug(message: string, ...args: unknown[]): void {
       if (shouldLog('debug')) {
+        let context: LogContext = {};
         if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null && !Array.isArray(args[0])) {
-          const context = prepareContext(args[0] as LogContext);
-          console.debug(formatLogEntry('debug', message), context);
-        } else {
-          console.debug(formatLogEntry('debug', message), ...args);
+          context = args[0] as LogContext;
+        } else if (args.length > 0) {
+          // Treat multiple arguments as an array in the context
+          context = { args };
         }
+        const logEntry = { level: 'debug', message, ...prepareContext(context) };
+        // Output JSON string to stdout
+        console.log(JSON.stringify(logEntry));
       }
     },
 
     info(message: string, ...args: unknown[]): void {
       if (shouldLog('info')) {
+        let context: LogContext = {};
         if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null && !Array.isArray(args[0])) {
-          const context = prepareContext(args[0] as LogContext);
-          console.info(formatLogEntry('info', message), context);
-        } else {
-          console.info(formatLogEntry('info', message), ...args);
+          context = args[0] as LogContext;
+        } else if (args.length > 0) {
+          context = { args };
         }
+        const logEntry = { level: 'info', message, ...prepareContext(context) };
+        // Output JSON string to stdout
+        console.log(JSON.stringify(logEntry));
       }
     },
 
     warn(message: string, ...args: unknown[]): void {
       if (shouldLog('warn')) {
+        let context: LogContext = {};
         if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null && !Array.isArray(args[0])) {
-          const context = prepareContext(args[0] as LogContext);
-          console.warn(formatLogEntry('warn', message), context);
-        } else {
-          console.warn(formatLogEntry('warn', message), ...args);
+          context = args[0] as LogContext;
+        } else if (args.length > 0) {
+          context = { args };
         }
+        const logEntry = { level: 'warn', message, ...prepareContext(context) };
+        // Output JSON string to stdout
+        console.log(JSON.stringify(logEntry));
       }
     },
 
     error(message: string, ...args: unknown[]): void {
       if (shouldLog('error')) {
-        if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null && !Array.isArray(args[0])) {
-          const context = prepareContext(args[0] as LogContext);
-          console.error(formatLogEntry('error', message), context);
-        } else {
-          console.error(formatLogEntry('error', message), ...args);
+        let context: LogContext = {};
+        // Ensure error details are captured correctly in context
+        const errorArg = args.find(arg => arg instanceof Error);
+        if (errorArg) {
+           context.error = {
+             message: (errorArg as Error).message,
+             stack: (errorArg as Error).stack,
+             name: (errorArg as Error).name,
+           };
+           // Filter out the error object from args if it exists
+           args = args.filter(arg => arg !== errorArg);
         }
+
+        if (args.length === 1 && typeof args[0] === 'object' && args[0] !== null && !Array.isArray(args[0])) {
+           // Merge remaining args[0] if it's an object context
+           context = { ...context, ...(args[0] as LogContext) };
+        } else if (args.length > 0) {
+           // Add remaining args if any
+           context.args = args;
+        }
+
+        const logEntry = { level: 'error', message, ...prepareContext(context) };
+        // Output JSON string to stdout
+        console.log(JSON.stringify(logEntry));
       }
     },
 

--- a/packages/mcp/tests/integration/controller/BranchController.integration.test.ts
+++ b/packages/mcp/tests/integration/controller/BranchController.integration.test.ts
@@ -7,7 +7,7 @@ import { BranchController } from '../../../src/interface/controllers/BranchContr
 import type { DocumentDTO } from '../../../src/application/dtos/DocumentDTO.js'; // Import DocumentDTO for type guard
 // ★★★ WriteBranchDocumentOutput をインポート ★★★
 import type { WriteBranchDocumentOutput } from '../../../src/application/usecases/branch/WriteBranchDocumentUseCase.js';
-
+import { logger } from '../../../src/shared/utils/logger.js'; // みらい: logger をインポート
 // Custom Type Guard function to check if data matches the expected output structure
 // (content and tags are optional)
 function isWriteBranchDocumentOutputData(data: any): data is WriteBranchDocumentOutput['document'] {
@@ -82,7 +82,7 @@ describe('BranchController Integration Tests', () => {
       // ★★★ タイプガードの条件を反転させ、エラーケースを先に処理 ★★★
       if (!isWriteBranchDocumentOutputData(writeResult.data)) {
           // Log the actual data for debugging if the type guard fails
-          console.error("--- Assertion Error: writeResult.data did not match expected output structure. Actual data:", JSON.stringify(writeResult.data, null, 2));
+          logger.error("--- Assertion Error: writeResult.data did not match expected output structure.", { actualData: writeResult.data, component: 'BranchController.integration.test' }); // みらい: console.error を logger.error に変更
           throw new Error('Expected writeResult.data to match the expected output structure');
       }
       // ★★★ タイプガードの後なので安全にアクセスできる ★★★
@@ -95,7 +95,7 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.data).toBeDefined();
       // readResult.data の型ガードも追加 (readDocument は DocumentDTO を返す想定)
       if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          console.error("--- Assertion Error: readResult.data.document.content was not a string. Actual data:", JSON.stringify(readResult.data, null, 2));
+          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' }); // みらい: console.error を logger.error に変更
           throw new Error('Expected readResult.data.document.content to be a string');
       }
       const parsed = JSON.parse(readResult.data.document.content);
@@ -162,7 +162,7 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.data).toBeDefined();
       // readResult.data の型ガードも追加
       if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          console.error("--- Assertion Error: readResult.data.document.content was not a string. Actual data:", JSON.stringify(readResult.data, null, 2));
+          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' }); // みらい: console.error を logger.error に変更
           throw new Error('Expected readResult.data.document.content to be a string');
       }
       const parsed = JSON.parse(readResult.data.document.content);
@@ -213,7 +213,7 @@ describe('BranchController Integration Tests', () => {
       // ★★★ タイプガードの条件を反転させ、エラーケースを先に処理 ★★★
       if (!isWriteBranchDocumentOutputData(updateResult.data)) {
            // Log the actual data for debugging if the type guard fails
-           console.error("--- Assertion Error: updateResult.data did not match expected output structure. Actual data:", JSON.stringify(updateResult.data, null, 2));
+           logger.error("--- Assertion Error: updateResult.data did not match expected output structure.", { actualData: updateResult.data, component: 'BranchController.integration.test' }); // みらい: console.error を logger.error に変更
            throw new Error('Expected updateResult.data to match the expected output structure');
        }
        // ★★★ タイプガードの後なので安全にアクセスできる ★★★
@@ -226,7 +226,7 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.data).toBeDefined();
       // readResult.data の型ガードも追加
       if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          console.error("--- Assertion Error: readResult.data.document.content was not a string. Actual data:", JSON.stringify(readResult.data, null, 2));
+          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' }); // みらい: console.error を logger.error に変更
           throw new Error('Expected readResult.data.document.content to be a string');
       }
       const parsed = JSON.parse(readResult.data.document.content);

--- a/packages/mcp/tests/integration/helpers/test-env.ts
+++ b/packages/mcp/tests/integration/helpers/test-env.ts
@@ -161,13 +161,13 @@ export async function cleanupTestEnv(env: TestEnv): Promise<void> {
     await env.cleanup();
     logger.debug(`Cleaned up temp directory: ${env.tempDir}`);
   } catch (error) {
-    console.error('Error cleaning up test environment:', error);
+    logger.error('Error cleaning up test environment:', { error, component: 'test-env' }); // みらい: console.error を logger.error に変更
     // Attempt manual removal as fallback, but log the error
     try {
       await fs.remove(env.tempDir);
       logger.warn(`Fallback removal attempted for temp directory: ${env.tempDir}`);
     } catch (fallbackError) {
-      console.error('Fallback removal failed:', fallbackError);
+      logger.error('Fallback removal failed:', { error: fallbackError, component: 'test-env' }); // みらい: console.error を logger.error に変更
     }
   }
 }

--- a/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
@@ -9,7 +9,7 @@ import { ReadRulesUseCase } from '../../../src/application/usecases/common/ReadR
 import { DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import type { IBranchMemoryBankRepository } from '../../../src/domain/repositories/IBranchMemoryBankRepository.js';
 import fs from 'fs/promises';
-
+import { logger } from '../../../src/shared/utils/logger.js'; // みらい: logger をインポート
 import * as path from 'path';
 
 describe('ReadContextUseCase Integration Tests', () => {
@@ -140,9 +140,9 @@ describe('ReadContextUseCase Integration Tests', () => {
       const branchPath = path.join(testEnv.branchMemoryPath, toSafeBranchName(nonExistentBranch));
       try {
         const filesDirectly = await fs.readdir(branchPath);
-        console.log('[Mirai Debug] Files immediately after initialize:', filesDirectly.sort()); // ★デバッグログ追加 (ソート済み)
+        logger.debug('[Mirai Debug] Files immediately after initialize:', { files: filesDirectly.sort(), component: 'ReadContextUseCase.integration.test' }); // みらい: console.log を logger.debug に変更
       } catch (e) {
-        console.error('[Mirai Debug] Error reading directory after initialize:', e);
+        logger.error('[Mirai Debug] Error reading directory after initialize:', { error: e, component: 'ReadContextUseCase.integration.test' }); // みらい: console.error を logger.error に変更
       }
       // --- みらい：ここまで ---
 

--- a/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts
@@ -387,11 +387,11 @@ describe('WriteBranchDocumentUseCase Integration Tests', () => {
       expect(readResult.document).toBeDefined();
       // Log the actual content read from the file for debugging
       // Log the raw content string read from the file before parsing
-      console.error('--- Raw content after patch read from file:', readResult.document.content);
+      logger.error('--- Raw content after patch read from file:', { content: readResult.document.content, component: 'WriteBranchDocumentUseCase.integration.test' }); // みらい: console.error を logger.error に変更
 
       const readDocument = JSON.parse(readResult.document.content);
       // Log the parsed document object for debugging
-      console.error('--- Parsed document object:', JSON.stringify(readDocument, null, 2));
+      logger.error('--- Parsed document object:', { document: readDocument, component: 'WriteBranchDocumentUseCase.integration.test' }); // みらい: console.error を logger.error に変更
       expect(readDocument.items).toEqual(["apple", "banana"]); // Verify patch applied correctly
       // Also verify tags if they were updated
       expect(readResult.document.tags).toEqual(["test", "patch", "updated"]);

--- a/packages/mcp/tests/integration/usecase/WriteGlobalDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/WriteGlobalDocumentUseCase.integration.test.ts
@@ -9,6 +9,7 @@ import { ReadGlobalDocumentUseCase } from '../../../src/application/usecases/glo
 import { DomainError, DomainErrors } from '../../../src/shared/errors/DomainError.js'; // Import specific errors for checking
 import { ApplicationError, ApplicationErrors } from '../../../src/shared/errors/ApplicationError.js'; // ★ ApplicationError クラスもインポート
 import * as rfc6902 from 'rfc6902'; // ★ デバッグ用にインポート
+import { logger } from '../../../src/shared/utils/logger.js'; // みらい: logger をインポート
 
 import fs from 'fs-extra'; // Use default import for fs-extra
 import * as path from 'path';
@@ -467,12 +468,12 @@ describe('WriteGlobalDocumentUseCase Integration Tests', () => {
           patchError = e;
         }
 
-        console.log('★★★ Debug: Error during applyPatch (if any):', patchError);
+        logger.debug('★★★ Debug: Error during applyPatch (if any):', { error: patchError, component: 'WriteGlobalDocumentUseCase.integration.test' }); // みらい: console.log を logger.debug に変更
         // 元のオブジェクトが変更されていないか確認 (ディープコピーしたので変更されていないはず)
-        console.log('★★★ Debug: Initial Object (after patch attempt):', JSON.stringify(initialContentObjectForDebug, null, 2));
-        console.log('★★★ Debug: Directly Patched Object (result):', JSON.stringify(directlyPatchedObject, null, 2));
+        logger.debug('★★★ Debug: Initial Object (after patch attempt):', { object: initialContentObjectForDebug, component: 'WriteGlobalDocumentUseCase.integration.test' }); // みらい: console.log を logger.debug に変更
+        logger.debug('★★★ Debug: Directly Patched Object (result):', { object: directlyPatchedObject, component: 'WriteGlobalDocumentUseCase.integration.test' }); // みらい: console.log を logger.debug に変更
       } catch (debugError) {
-        console.error('★★★ Debug: Error during outer debug block:', debugError);
+        logger.error('★★★ Debug: Error during outer debug block:', { error: debugError, component: 'WriteGlobalDocumentUseCase.integration.test' }); // みらい: console.error を logger.error に変更
       }
       // ★★★ デバッグ用ここまで ★★★
 
@@ -512,7 +513,7 @@ describe('WriteGlobalDocumentUseCase Integration Tests', () => {
       const patchesAgain = [{ op: 'replace', path: '/content/value', value: 'Patched Again' } as const]; // ★ as const
       const finalTagsAgain = ['test', 'integration', 'patched', 'again'];
       // ★★★ デバッグ: 2回目の実行直前の引数を確認 ★★★
-      console.log('★★★ Debug: Executing 2nd patch with:', { patches: patchesAgain, tags: finalTagsAgain });
+      logger.debug('★★★ Debug: Executing 2nd patch with:', { patches: patchesAgain, tags: finalTagsAgain, component: 'WriteGlobalDocumentUseCase.integration.test' }); // みらい: console.log を logger.debug に変更
       const resultWithoutContent = await writeUseCase.execute({
         // ★ as any でキャスト
         document: {


### PR DESCRIPTION
# Refactor Logger Usage

This change refactors the logger usage across the application to use a standardized logger and improve logging practices, especially for JSON-RPC communication.

## ♻️ Refactoring

*   **Standardized Logger:** Replaced direct `console.*` calls with the standardized logger (`shared/utils/logger`).
*   **JSON Output:** Updated the logger implementation to output logs in JSON format to `stdout`, preventing interference with JSON-RPC communication.
*   **Log Cleanup:** Removed commented-out debug logs and replaced temporary test logs with appropriate logger levels (`logger.debug`, `logger.error`, etc.).
*   **Deprecated Logger:** Updated `console.warn` calls in the deprecated `LoggerFactory` to use the new logger.
