### PR TITLE
Fix: Prevent .md file creation during initialization (#89)

### DIFF
--- a/docs/branch-memory-bank/fix-issue-89/activeContext.json
+++ b/docs/branch-memory-bank/fix-issue-89/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-89-active-context",
+    "title": "Active Context for fix/issue-89",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T04:52:06.678Z",
+    "lastModified": "2025-04-04T04:52:06.678Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: fix/issue-89",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/branch-memory-bank/fix-issue-89/branchContext.json
+++ b/docs/branch-memory-bank/fix-issue-89/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-89-context",
+    "title": "Branch Context for fix/issue-89",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T04:52:06.678Z",
+    "lastModified": "2025-04-04T04:52:06.678Z"
+  },
+  "content": {
+    "description": "Context for branch: fix/issue-89"
+  }
+}

--- a/docs/branch-memory-bank/fix-issue-89/progress.json
+++ b/docs/branch-memory-bank/fix-issue-89/progress.json
@@ -1,0 +1,30 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-89-progress",
+    "title": "Progress for fix/issue-89",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-04T13:52:00+09:00",
+    "lastModified": "2025-04-04T04:52:36.818Z",
+    "version": 2
+  },
+  "content": {
+    "summary": "Initial progress for branch: fix/issue-89",
+    "status": "修正完了、コミット待ち",
+    "workingFeatures": [],
+    "pendingImplementation": [],
+    "completionPercentage": 0,
+    "knownIssues": [],
+    "recentChanges": [
+      {
+        "date": "2025-04-04T13:51:00+09:00",
+        "description": "Issue #89 の修正: DocumentIO.ts で JSON 保存時に .md ファイルも作成する処理を削除したよ！",
+        "files": [
+          "packages/mcp/src/infrastructure/repositories/file-system/DocumentIO.ts"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/fix-issue-89/systemPatterns.json
+++ b/docs/branch-memory-bank/fix-issue-89/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issue-89-system-patterns",
+    "title": "System Patterns for fix/issue-89",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T04:52:06.678Z",
+    "lastModified": "2025-04-04T04:52:06.678Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/packages/mcp/src/infrastructure/repositories/file-system/DocumentIO.ts
+++ b/packages/mcp/src/infrastructure/repositories/file-system/DocumentIO.ts
@@ -172,14 +172,7 @@ export class DocumentIO {
       await fs.writeFile(filePath, contentToSave, 'utf-8');
       logger.debug('[DocumentIO] Successfully wrote file:', { filePath });
 
-      // Write .md version if the main file is .json (for test compatibility)
-      if (isJsonFile) {
-        const mdFilePath = filePath.replace('.json', '.md');
-        const mdParentDir = path.dirname(mdFilePath);
-        await fs.mkdir(mdParentDir, { recursive: true });
-        await fs.writeFile(mdFilePath, contentToSave, 'utf-8');
-        logger.debug('[DocumentIO] Successfully wrote MD version:', { path: mdFilePath });
-      }
+      // みらい... .md ファイル作成処理を削除 (Issue #89 対応)
 
     } catch (error: unknown) {
       logger.error('[DocumentIO] Failed to save document:', { filePath, error });


### PR DESCRIPTION
# Fix: Prevent .md file creation during initialization (Issue #89)

## Description

This PR addresses issue #89 by removing the logic that unnecessarily created `.md` files alongside `.json` files when saving documents in the `DocumentIO` class. This ensures that only JSON files are created, adhering to the project's standards.

## Changes Made

- Removed the code block responsible for creating `.md` files in `packages/mcp/src/infrastructure/repositories/file-system/DocumentIO.ts`.

## Related Issue

Closes #89
