### PR TITLE
Fix unit test errors in common use cases

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -9,6 +9,7 @@
     "@semantic-release/npm",
     "@semantic-release/release-notes-generator",
     "conventional-changelog-conventionalcommits",
-    "semantic-release"
+    "semantic-release",
+    "jest-mock-extended"
   ]
 }

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/activeContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-common-active-context",
+    "title": "Active Context for feature/unit-test-app-common",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:45:52.115Z",
+    "lastModified": "2025-04-04T16:45:52.115Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: feature/unit-test-app-common",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/branchContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-common-context",
+    "title": "Branch Context for feature/unit-test-app-common",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:45:52.115Z",
+    "lastModified": "2025-04-04T16:45:52.115Z"
+  },
+  "content": {
+    "description": "Context for branch: feature/unit-test-app-common"
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
@@ -7,7 +7,7 @@
     "path": "progress.json",
     "tags": [],
     "createdAt": "2025-04-05T01:45:45.000Z",
-    "lastModified": "2025-04-04T16:45:52.116Z"
+    "lastModified": "2025-04-04T17:00:40.001Z"
   },
   "content": {
     "summary": "Application層 (共通ユースケース) の単体テストスケルトン作成",

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
@@ -7,23 +7,53 @@
     "path": "progress.json",
     "tags": [],
     "createdAt": "2025-04-05T01:45:45.000Z",
-    "lastModified": "2025-04-04T17:00:40.001Z"
+    "lastModified": "2025-04-04T18:05:14.740Z"
   },
   "content": {
-    "summary": "Application層 (共通ユースケース) の単体テストスケルトン作成",
+    "summary": "共通ユースケースの単体テストスケルトン作成と初期エラー修正中",
     "status": "in_progress",
     "steps": [
       {
         "description": "共通ユースケース (CreateBranchCoreFiles, GetRecentBranches, ReadBranchCoreFiles, ReadContext, ReadRules, SearchDocumentsByTags, UpdateTagIndex, UpdateTagIndexV2) のテストスケルトン作成",
         "status": "done"
+      },
+      {
+        "description": "初期テスト実行とエラー修正",
+        "status": "in_progress"
       }
     ],
     "next_steps": [
       {
-        "description": "各スケルトンファイルに具体的なテストケースを実装する",
+        "description": "残りのテストエラー (ReadRules, ReadBranchCoreFiles, CreateBranchCoreFiles, GetRecentBranches) を修正する",
         "status": "todo"
       }
     ],
-    "findings": []
+    "findings": [
+      {
+        "description": "ReadBranchCoreFilesUseCase.test.ts で構文エラー (括弧の対応) が発生している疑い",
+        "type": "issue",
+        "details": "テスト実行時に '}' expected エラーが発生。diff適用時の閉じ括弧修正が原因の可能性。",
+        "file": "packages/mcp/tests/unit/application/usecases/common/ReadBranchCoreFilesUseCase.test.ts"
+      },
+      {
+        "description": "ReadRulesUseCase.test.ts でエラーメッセージの toMatch が失敗している",
+        "type": "issue",
+        "details": "期待する正規表現と実際のエラーメッセージが一致していない。",
+        "file": "packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts"
+      },
+      {
+        "description": "CreateBranchCoreFilesUseCase.test.ts, GetRecentBranchesUseCase.test.ts でエラーコードの比較 (toHaveProperty) が失敗している",
+        "type": "issue",
+        "details": "期待するエラーコード文字列と実際のエラーコード文字列が異なっている。",
+        "files": [
+          "packages/mcp/tests/unit/application/usecases/common/CreateBranchCoreFiles.test.ts",
+          "packages/mcp/tests/unit/application/usecases/common/GetRecentBranchesUseCase.test.ts"
+        ]
+      },
+      {
+        "description": "エラーコードの実際の値が 'DOMAIN_ERROR.XXX' や 'APP_ERROR.XXX' の形式である可能性が高い",
+        "type": "insight"
+      }
+    ]
   }
 }

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/progress.json
@@ -1,0 +1,29 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-common-progress",
+    "title": "Progress for feature/unit-test-app-common",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-05T01:45:45.000Z",
+    "lastModified": "2025-04-04T16:45:52.116Z"
+  },
+  "content": {
+    "summary": "Application層 (共通ユースケース) の単体テストスケルトン作成",
+    "status": "in_progress",
+    "steps": [
+      {
+        "description": "共通ユースケース (CreateBranchCoreFiles, GetRecentBranches, ReadBranchCoreFiles, ReadContext, ReadRules, SearchDocumentsByTags, UpdateTagIndex, UpdateTagIndexV2) のテストスケルトン作成",
+        "status": "done"
+      }
+    ],
+    "next_steps": [
+      {
+        "description": "各スケルトンファイルに具体的なテストケースを実装する",
+        "status": "todo"
+      }
+    ],
+    "findings": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-common/systemPatterns.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-common/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-common-system-patterns",
+    "title": "System Patterns for feature/unit-test-app-common",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:45:52.115Z",
+    "lastModified": "2025-04-04T16:45:52.115Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-json/activeContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-json/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-json-active-context",
+    "title": "Active Context for feature/unit-test-app-json",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:46:07.303Z",
+    "lastModified": "2025-04-04T16:46:07.303Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: feature/unit-test-app-json",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-json/branchContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-json/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-json-context",
+    "title": "Branch Context for feature/unit-test-app-json",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:46:07.303Z",
+    "lastModified": "2025-04-04T16:46:07.303Z"
+  },
+  "content": {
+    "description": "Context for branch: feature/unit-test-app-json"
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-json/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-json/progress.json
@@ -1,0 +1,29 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-json-progress",
+    "title": "Progress for feature/unit-test-app-json",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-05T01:46:00.000Z",
+    "lastModified": "2025-04-04T16:46:07.304Z"
+  },
+  "content": {
+    "summary": "Application層 (JSON関連ユースケース) の単体テストスケルトン作成",
+    "status": "in_progress",
+    "steps": [
+      {
+        "description": "JSON関連ユースケース (DeleteJsonDocument, JsonPatch, ReadJsonDocument, SearchJsonDocuments, UpdateJsonIndex, WriteJsonDocument) のテストスケルトン作成",
+        "status": "done"
+      }
+    ],
+    "next_steps": [
+      {
+        "description": "各スケルトンファイルに具体的なテストケースを実装する",
+        "status": "todo"
+      }
+    ],
+    "findings": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-app-json/systemPatterns.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-app-json/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-app-json-system-patterns",
+    "title": "System Patterns for feature/unit-test-app-json",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:46:07.303Z",
+    "lastModified": "2025-04-04T16:46:07.303Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-base/activeContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-base/activeContext.json
@@ -1,0 +1,33 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-base-active-context",
+    "title": "Active Context for feature/unit-test-base",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:01:27.674Z",
+    "lastModified": "2025-04-04T16:02:15.532Z"
+  },
+  "content": {
+    "current_task": "packages/mcp のドメインエンティティに対する単体テストの実装",
+    "relevant_files": [
+      "packages/mcp/src/domain/entities/",
+      "packages/mcp/tests/unit/domain/entities/BranchInfo.test.ts",
+      "packages/mcp/tests/unit/domain/entities/DocumentId.test.ts",
+      "packages/mcp/tests/unit/domain/entities/DocumentPath.test.ts",
+      "packages/mcp/tests/unit/domain/entities/DocumentVersionInfo.test.ts",
+      "packages/mcp/tests/unit/domain/entities/JsonDocument.test.ts",
+      "packages/mcp/tests/unit/domain/entities/MemoryDocument.test.ts",
+      "packages/mcp/tests/unit/domain/entities/Tag.test.ts",
+      "packages/mcp/tests/unit/domain/entities/BranchName.test.ts",
+      "packages/mcp/tests/unit/domain/entities/BranchPath.test.ts",
+      "packages/mcp/tests/unit/domain/entities/Document.test.ts",
+      "packages/mcp/tests/unit/domain/entities/MemoryBankIndex.test.ts",
+      "packages/mcp/tests/unit/domain/entities/TagIndex.test.ts"
+    ],
+    "recent_decisions": [
+      "ドメインエンティティごとに単体テストを追加していく方針を採用"
+    ]
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-base/branchContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-base/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-base-context",
+    "title": "Branch Context for feature/unit-test-base",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:01:27.674Z",
+    "lastModified": "2025-04-04T16:01:27.674Z"
+  },
+  "content": {
+    "description": "Context for branch: feature/unit-test-base"
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-base/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-base/progress.json
@@ -1,0 +1,49 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-base-progress",
+    "title": "Progress for feature/unit-test-base",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:01:27.674Z",
+    "lastModified": "2025-04-04T16:01:59.896Z"
+  },
+  "content": {
+    "summary": "ドメインエンティティの単体テスト基盤構築と初期テスト実装",
+    "status": "in_progress",
+    "steps": [
+      {
+        "description": "単体テストのスケルトン作成 (b5047784)",
+        "status": "done"
+      },
+      {
+        "description": "コア ドメインエンティティ (BranchInfo, DocumentId, DocumentVersionInfo) の単体テスト追加 (85df919c)",
+        "status": "done"
+      },
+      {
+        "description": "その他のドメインエンティティ (BranchName, BranchPath, Document, MemoryBankIndex, TagIndex) の単体テスト追加 (27b12754)",
+        "status": "done"
+      },
+      {
+        "description": "WriteDocument ユースケースのリファクタリング (e09fefc2)",
+        "status": "done"
+      },
+      {
+        "description": "ロギングの改善 (db7faf75, d3863b78)",
+        "status": "done"
+      },
+      {
+        "description": "その他修正 (1f1ae880, bacf1d63, 4cd9f63b, 32b08df1)",
+        "status": "done"
+      }
+    ],
+    "next_steps": [
+      {
+        "description": "残りのドメインエンティティやユースケースの単体テストを追加する",
+        "status": "todo"
+      }
+    ],
+    "findings": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-base/systemPatterns.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-base/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-base-system-patterns",
+    "title": "System Patterns for feature/unit-test-base",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:01:27.674Z",
+    "lastModified": "2025-04-04T16:01:27.674Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-infra-interface/activeContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-infra-interface/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-infra-interface-active-context",
+    "title": "Active Context for feature/unit-test-infra-interface",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:44:43.181Z",
+    "lastModified": "2025-04-04T16:44:43.181Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: feature/unit-test-infra-interface",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-infra-interface/branchContext.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-infra-interface/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-infra-interface-context",
+    "title": "Branch Context for feature/unit-test-infra-interface",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:44:43.181Z",
+    "lastModified": "2025-04-04T16:44:43.181Z"
+  },
+  "content": {
+    "description": "Context for branch: feature/unit-test-infra-interface"
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-infra-interface/progress.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-infra-interface/progress.json
@@ -1,0 +1,33 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-infra-interface-progress",
+    "title": "Progress for feature/unit-test-infra-interface",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-05T01:44:30.000Z",
+    "lastModified": "2025-04-04T16:44:43.182Z"
+  },
+  "content": {
+    "summary": "Infrastructure層とInterface層の単体テストスケルトン作成",
+    "status": "in_progress",
+    "steps": [
+      {
+        "description": "Infrastructure層 (repositories, git, index, logger, storage, templates, validation) のテストスケルトン作成",
+        "status": "done"
+      },
+      {
+        "description": "Interface層 (controllers) のテストスケルトン作成",
+        "status": "done"
+      }
+    ],
+    "next_steps": [
+      {
+        "description": "各スケルトンファイルに具体的なテストケースを実装する",
+        "status": "todo"
+      }
+    ],
+    "findings": []
+  }
+}

--- a/docs/test/branch-memory-bank/feature-unit-test-infra-interface/systemPatterns.json
+++ b/docs/test/branch-memory-bank/feature-unit-test-infra-interface/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "feature-unit-test-infra-interface-system-patterns",
+    "title": "System Patterns for feature/unit-test-infra-interface",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-04T16:44:43.181Z",
+    "lastModified": "2025-04-04T16:44:43.181Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-import": "^2.31.0",
     "globals": "^16.0.0",
     "husky": "^9.1.7",
+    "jest-mock-extended": "^4.0.0-beta1",
     "lint-staged": "^15.5.0",
     "madge": "^7.0.0",
     "prettier": "^3.5.3",

--- a/packages/mcp/src/application/usecases/common/ReadBranchCoreFilesUseCase.ts
+++ b/packages/mcp/src/application/usecases/common/ReadBranchCoreFilesUseCase.ts
@@ -76,13 +76,11 @@ export class ReadBranchCoreFilesUseCase implements IUseCase<ReadBranchCoreFilesI
         }
       } catch (error) {
         if (error instanceof DomainError || error instanceof ApplicationError) {
-          throw error;
+          throw error; // Known errors are re-thrown
         }
-        logger.debug('Document not found', {
-          type: 'activeContext',
-          path: this.ACTIVE_CONTEXT_PATH,
-          branch: input.branchName
-        });
+        // Unexpected errors are wrapped and thrown as ApplicationError
+        logger.error('Unexpected error reading activeContext', { path: this.ACTIVE_CONTEXT_PATH, branch: input.branchName, error });
+        throw new ApplicationError(ApplicationErrorCodes.USE_CASE_EXECUTION_FAILED, `Failed to read activeContext: ${(error as Error).message}`, { originalError: error });
       }
 
       try {
@@ -95,13 +93,11 @@ export class ReadBranchCoreFilesUseCase implements IUseCase<ReadBranchCoreFilesI
         }
       } catch (error) {
         if (error instanceof DomainError || error instanceof ApplicationError) {
-          throw error;
+          throw error; // Known errors are re-thrown
         }
-        logger.debug('Document not found', {
-          type: 'progress',
-          path: this.PROGRESS_PATH,
-          branch: input.branchName
-        });
+        // Unexpected errors are wrapped and thrown as ApplicationError
+        logger.error('Unexpected error reading progress', { path: this.PROGRESS_PATH, branch: input.branchName, error });
+        throw new ApplicationError(ApplicationErrorCodes.USE_CASE_EXECUTION_FAILED, `Failed to read progress: ${(error as Error).message}`, { originalError: error });
       }
 
       try {
@@ -114,13 +110,11 @@ export class ReadBranchCoreFilesUseCase implements IUseCase<ReadBranchCoreFilesI
         }
       } catch (error) {
         if (error instanceof DomainError || error instanceof ApplicationError) {
-          throw error;
+          throw error; // Known errors are re-thrown
         }
-        logger.debug('Document not found', {
-          type: 'branchContext',
-          path: this.BRANCH_CONTEXT_PATH,
-          branch: input.branchName
-        });
+        // Unexpected errors are wrapped and thrown as ApplicationError
+        logger.error('Unexpected error reading branchContext', { path: this.BRANCH_CONTEXT_PATH, branch: input.branchName, error });
+        throw new ApplicationError(ApplicationErrorCodes.USE_CASE_EXECUTION_FAILED, `Failed to read branchContext: ${(error as Error).message}`, { originalError: error });
       }
 
       let systemPatternsFound = false;
@@ -135,13 +129,11 @@ export class ReadBranchCoreFilesUseCase implements IUseCase<ReadBranchCoreFilesI
         }
       } catch (error) {
         if (error instanceof DomainError || error instanceof ApplicationError) {
-          throw error;
+          throw error; // Known errors are re-thrown
         }
-        logger.debug('Document not found', {
-          type: 'systemPatterns',
-          path: this.SYSTEM_PATTERNS_PATH,
-          branch: input.branchName
-        });
+        // Unexpected errors are wrapped and thrown as ApplicationError
+        logger.error('Unexpected error reading systemPatterns', { path: this.SYSTEM_PATTERNS_PATH, branch: input.branchName, error });
+        throw new ApplicationError(ApplicationErrorCodes.USE_CASE_EXECUTION_FAILED, `Failed to read systemPatterns: ${(error as Error).message}`, { originalError: error });
       }
 
       // Set default value if SystemPatterns was not found

--- a/packages/mcp/tests/unit/application/usecases/common/CreateBranchCoreFiles.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/CreateBranchCoreFiles.test.ts
@@ -1,0 +1,38 @@
+import { CreateBranchCoreFilesUseCase } from '../../../../../src/application/usecases/common/CreateBranchCoreFilesUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { CoreFilesDTO } from '../../../../../src/application/dtos/CoreFilesDTO.js';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { mock } from 'jest-mock-extended';
+
+describe('CreateBranchCoreFilesUseCase', () => {
+  let useCase: CreateBranchCoreFilesUseCase;
+  let mockMemoryBankRepository: jest.Mocked<IBranchMemoryBankRepository>;
+
+  beforeEach(() => {
+    mockMemoryBankRepository = mock<IBranchMemoryBankRepository>();
+    useCase = new CreateBranchCoreFilesUseCase(mockMemoryBankRepository);
+  });
+
+  it('should call branchRepository.saveDocument 4 times when creating core files for a new branch', async () => {
+    // Arrange
+    const branchName = 'feature/new-branch';
+    const branchInfo = BranchInfo.create(branchName);
+    const files: CoreFilesDTO = { // CoreFilesDTO の最低限のモック
+      branchContext: 'test branch context',
+      activeContext: {}, // ActiveContextDTO の最低限
+      progress: {},      // ProgressDTO の最低限
+      systemPatterns: { technicalDecisions: [{ title: 'dummy', context: 'dummy', decision: 'dummy', consequences: [] }] }
+    };
+    mockMemoryBankRepository.exists.mockResolvedValue(true);
+
+    // Act
+    await useCase.execute({ branchName, files });
+
+    // Assert
+    // UseCase内でsaveDocumentを呼んでいるため、saveDocumentの呼び出し回数を確認
+    expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledTimes(4); // progress, activeContext, branchContext, systemPatterns
+    // Add more specific assertions here
+  });
+
+  // TODO: Add more test cases for edge cases and error handling
+});

--- a/packages/mcp/tests/unit/application/usecases/common/CreateBranchCoreFiles.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/CreateBranchCoreFiles.test.ts
@@ -29,10 +29,112 @@ describe('CreateBranchCoreFilesUseCase', () => {
     await useCase.execute({ branchName, files });
 
     // Assert
-    // UseCase内でsaveDocumentを呼んでいるため、saveDocumentの呼び出し回数を確認
-    expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledTimes(4); // progress, activeContext, branchContext, systemPatterns
-    // Add more specific assertions here
+    // expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledTimes(4); // 回数チェックをやめて個別チェックにする
+    // 各ファイルが正しい引数で保存されようとしたかチェック
+    expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledWith(
+      branchInfo,
+      expect.objectContaining({
+        path: expect.objectContaining({ value: 'branchContext.json' }),
+        content: files.branchContext,
+        tags: expect.arrayContaining([expect.objectContaining({ value: 'core' }), expect.objectContaining({ value: 'branch-context' })])
+      })
+    );
+     expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledWith(
+      branchInfo,
+      expect.objectContaining({
+        path: expect.objectContaining({ value: 'activeContext.json' }),
+        content: expect.any(String), // 中身は生成されるので型だけチェック
+        tags: expect.arrayContaining([expect.objectContaining({ value: 'core' }), expect.objectContaining({ value: 'active-context' })])
+      })
+    );
+     expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledWith(
+      branchInfo,
+      expect.objectContaining({
+        path: expect.objectContaining({ value: 'progress.json' }),
+        content: expect.any(String), // 中身は生成されるので型だけチェック
+        tags: expect.arrayContaining([expect.objectContaining({ value: 'core' }), expect.objectContaining({ value: 'progress' })])
+      })
+    );
+     expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledWith(
+      branchInfo,
+      expect.objectContaining({
+        path: expect.objectContaining({ value: 'systemPatterns.json' }),
+        content: expect.any(String), // 中身は生成されるので型だけチェック
+        tags: expect.arrayContaining([expect.objectContaining({ value: 'core' }), expect.objectContaining({ value: 'system-patterns' })])
+      })
+    );
   });
 
-  // TODO: Add more test cases for edge cases and error handling
+  it('should throw ApplicationError if branchName is missing', async () => {
+    // Arrange
+    const files: CoreFilesDTO = { branchContext: 'test' }; // filesは何か必要
+
+    // Act & Assert
+    try {
+      await useCase.execute({ branchName: '', files });
+      throw new Error('Expected ApplicationError to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('code', 'APP_ERROR.INVALID_INPUT'); // プレフィックス付きで比較
+      expect((error as Error).message).toBe('Branch name is required');
+    }
+    expect(mockMemoryBankRepository.saveDocument).not.toHaveBeenCalled();
+  });
+
+   it('should throw ApplicationError if files data is missing', async () => {
+    // Arrange
+    const branchName = 'feature/no-files';
+
+    // Act & Assert
+    try {
+      // @ts-expect-error files is required
+      await useCase.execute({ branchName, files: undefined });
+      throw new Error('Expected ApplicationError to be thrown');
+    } catch (error) {
+       expect(error).toBeInstanceOf(Error);
+       expect(error).toHaveProperty('code', 'APP_ERROR.INVALID_INPUT'); // プレフィックス付きで比較
+       expect((error as Error).message).toBe('Core files data is required');
+    }
+     expect(mockMemoryBankRepository.saveDocument).not.toHaveBeenCalled();
+  });
+
+   it('should throw DomainError if branch does not exist', async () => {
+    // Arrange
+    const branchName = 'feature/non-existent';
+    const files: CoreFilesDTO = { branchContext: 'test' };
+    mockMemoryBankRepository.exists.mockResolvedValue(false); // ブランチが存在しないケース
+
+    // Act & Assert
+    try {
+      await useCase.execute({ branchName, files });
+      throw new Error('Expected DomainError to be thrown');
+    } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toHaveProperty('code', 'DOMAIN_ERROR.BRANCH_NOT_FOUND'); // プレフィックス付きで比較
+        expect((error as Error).message).toBe(`Branch "${branchName}" not found`);
+    }
+     expect(mockMemoryBankRepository.saveDocument).not.toHaveBeenCalled();
+  });
+
+   it('should throw ApplicationError if repository throws error during saveDocument', async () => {
+    // Arrange
+    const branchName = 'feature/save-error';
+     const branchInfo = BranchInfo.create(branchName);
+    const files: CoreFilesDTO = { branchContext: 'test context' }; // branchContextだけあればsaveDocumentが呼ばれる
+    mockMemoryBankRepository.exists.mockResolvedValue(true);
+    const saveError = new Error('Failed to save');
+    mockMemoryBankRepository.saveDocument.mockRejectedValue(saveError); // saveDocumentでエラー
+
+    // Act & Assert
+    try {
+      await useCase.execute({ branchName, files });
+      throw new Error('Expected ApplicationError to be thrown');
+    } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toHaveProperty('code', 'APP_ERROR.USE_CASE_EXECUTION_FAILED'); // プレフィックス付きで比較
+        expect((error as Error).message).toContain('Failed to create/update core files: Failed to save');
+        // originalError のチェックも追加した方がより確実だけど、一旦省略
+    }
+     expect(mockMemoryBankRepository.saveDocument).toHaveBeenCalledTimes(1); // 1回は呼ばれるはず
+  });
 });

--- a/packages/mcp/tests/unit/application/usecases/common/GetRecentBranchesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/GetRecentBranchesUseCase.test.ts
@@ -39,8 +39,56 @@ describe('GetRecentBranchesUseCase', () => {
 
     // Assert
     expect(result.branches).toHaveLength(0);
-    expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(5); // limit が渡されることを確認
+    expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(5);
   });
 
-  // TODO: Add more test cases for edge cases and error handling
+  it('should use default limit (10) if limit is not provided', async () => {
+    // Arrange
+    mockBranchRepository.getRecentBranches.mockResolvedValue([]); // 結果は空で良い
+
+    // Act
+    await useCase.execute({}); // limit を指定しない
+
+    // Assert
+    expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(10); // デフォルト値10が使われるはず
+  });
+
+  it('should throw ApplicationError if limit is less than 1', async () => {
+    // Act & Assert
+    try {
+      await useCase.execute({ limit: 0 });
+      throw new Error('Expected ApplicationError for limit 0');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('code', 'APP_ERROR.INVALID_INPUT'); // プレフィックス付きで比較
+      expect((error as Error).message).toBe('Limit must be a positive number');
+    }
+    try {
+      await useCase.execute({ limit: -1 });
+      throw new Error('Expected ApplicationError for limit -1');
+    } catch (error) {
+       expect(error).toBeInstanceOf(Error);
+       expect(error).toHaveProperty('code', 'APP_ERROR.INVALID_INPUT'); // プレフィックス付きで比較
+       expect((error as Error).message).toBe('Limit must be a positive number');
+    }
+    expect(mockBranchRepository.getRecentBranches).not.toHaveBeenCalled();
+  });
+
+   it('should throw ApplicationError if repository throws error', async () => {
+    // Arrange
+    const repoError = new Error('Database connection failed');
+    mockBranchRepository.getRecentBranches.mockRejectedValue(repoError);
+
+    // Act & Assert
+    try {
+      await useCase.execute({ limit: 5 });
+      throw new Error('Expected ApplicationError to be thrown');
+    } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toHaveProperty('code', 'APP_ERROR.USE_CASE_EXECUTION_FAILED'); // プレフィックス付きで比較
+        expect((error as Error).message).toContain('Failed to get recent branches: Database connection failed');
+        // originalError のチェックも追加した方がより確実だけど、一旦省略
+    }
+     expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(5); // リポジトリは呼ばれるはず
+  });
 });

--- a/packages/mcp/tests/unit/application/usecases/common/GetRecentBranchesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/GetRecentBranchesUseCase.test.ts
@@ -1,0 +1,46 @@
+import { GetRecentBranchesUseCase } from '../../../../../src/application/usecases/common/GetRecentBranchesUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+
+describe('GetRecentBranchesUseCase', () => {
+  let useCase: GetRecentBranchesUseCase;
+  let mockBranchRepository: jest.Mocked<IBranchMemoryBankRepository>;
+
+  beforeEach(() => {
+    mockBranchRepository = mock<IBranchMemoryBankRepository>();
+    useCase = new GetRecentBranchesUseCase(mockBranchRepository);
+  });
+
+  it('should return a list of recent branches', async () => {
+    // Arrange
+    const mockRecentBranches = [
+      { branchInfo: BranchInfo.create('feature/branch-1'), lastModified: new Date(), summary: { currentWork: 'Task 1', recentChanges: [] } },
+      { branchInfo: BranchInfo.create('feature/branch-2'), lastModified: new Date(), summary: { currentWork: 'Task 2', recentChanges: [] } },
+    ];
+    mockBranchRepository.getRecentBranches.mockResolvedValue(mockRecentBranches);
+
+    // Act
+    const result = await useCase.execute({ limit: 5 });
+
+    // Assert
+    expect(result.branches).toHaveLength(2);
+    expect(result.branches[0].name).toBe('feature/branch-1');
+    expect(result.branches[1].name).toBe('feature/branch-2');
+    expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(5); // limit が渡されることを確認
+  });
+
+  it('should return an empty list if no recent branches found', async () => {
+    // Arrange
+    mockBranchRepository.getRecentBranches.mockResolvedValue([]);
+
+    // Act
+    const result = await useCase.execute({ limit: 5 });
+
+    // Assert
+    expect(result.branches).toHaveLength(0);
+    expect(mockBranchRepository.getRecentBranches).toHaveBeenCalledWith(5); // limit が渡されることを確認
+  });
+
+  // TODO: Add more test cases for edge cases and error handling
+});

--- a/packages/mcp/tests/unit/application/usecases/common/ReadBranchCoreFilesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadBranchCoreFilesUseCase.test.ts
@@ -151,24 +151,24 @@ describe('ReadBranchCoreFilesUseCase', () => {
    mockBranchRepository.exists.mockResolvedValue(true);
   mockBranchRepository.getDocument
       .mockImplementation(async (argBranchInfo, argPath) => {
-          console.log(`[Test Debug] getDocument called with path: ${argPath.value}`); // みらいデバッグログ追加
+          console.log(`[Test Debug] getDocument called with path: ${argPath.value}`);
           if(argPath.equals(DocumentPath.create('activeContext.json'))) {
-              console.log('[Test Debug] Throwing error for activeContext.json'); // みらいデバッグログ追加
+              console.log('[Test Debug] Throwing error for activeContext.json');
               throw repoError;
           }
            if (argPath.equals(DocumentPath.create('progress.json'))) {
-               console.log('[Test Debug] Returning mockProgress'); // みらいデバッグログ追加
+               console.log('[Test Debug] Returning mockProgress');
                return mockProgress;
            }
            if (argPath.equals(DocumentPath.create('branchContext.json'))) {
-               console.log('[Test Debug] Returning mockBranchContext'); // みらいデバッグログ追加
+               console.log('[Test Debug] Returning mockBranchContext');
                return mockBranchContext;
            }
            if (argPath.equals(DocumentPath.create('systemPatterns.json'))) {
-               console.log('[Test Debug] Returning mockSystemPatterns'); // みらいデバッグログ追加
+               console.log('[Test Debug] Returning mockSystemPatterns');
                return mockSystemPatterns;
            }
-          console.log('[Test Debug] Returning null'); // みらいデバッグログ追加
+          console.log('[Test Debug] Returning null');
           return null;
       });
 
@@ -178,7 +178,7 @@ describe('ReadBranchCoreFilesUseCase', () => {
   await expect(useCase.execute({ branchName })).rejects.toThrowError(
       new ApplicationError(
           ApplicationErrorCodes.USE_CASE_EXECUTION_FAILED,
-          `Failed to read activeContext: ${repoError.message}`, // みらい修正: 実際に投げられるメッセージに合わせる
+          `Failed to read activeContext: ${repoError.message}`,
           { originalError: repoError }
       )
   );

--- a/packages/mcp/tests/unit/application/usecases/common/ReadBranchCoreFilesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadBranchCoreFilesUseCase.test.ts
@@ -1,0 +1,103 @@
+import { ReadBranchCoreFilesUseCase } from '../../../../../src/application/usecases/common/ReadBranchCoreFilesUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
+import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
+import { Tag } from '../../../../../src/domain/entities/Tag.js';
+
+describe('ReadBranchCoreFilesUseCase', () => {
+  let useCase: ReadBranchCoreFilesUseCase;
+  let mockBranchRepository: jest.Mocked<IBranchMemoryBankRepository>;
+
+  const branchName = 'feature/test-branch';
+  const branchInfo = BranchInfo.create(branchName);
+
+  const mockDocument = (path: string, content: object) =>
+    MemoryDocument.create({
+      path: DocumentPath.create(path),
+      content: JSON.stringify(content),
+      tags: [Tag.create('core')],
+      lastModified: new Date(),
+    });
+
+  const mockProgress = mockDocument('progress.json', { summary: 'Test Progress' });
+  const mockActiveContext = mockDocument('activeContext.json', { current_task: 'Test Task' });
+  const mockBranchContext = mockDocument('branchContext.json', { description: 'Test Context' });
+  const mockSystemPatterns = mockDocument('systemPatterns.json', { patterns: [] });
+
+
+  beforeEach(() => {
+    mockBranchRepository = mock<IBranchMemoryBankRepository>();
+    useCase = new ReadBranchCoreFilesUseCase(mockBranchRepository);
+  });
+
+  it('should return all core files when they exist', async () => {
+    // Arrange
+    mockBranchRepository.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+      if (!argBranchInfo.equals(branchInfo)) return null;
+      if (argPath.equals(DocumentPath.create('progress.json'))) return mockProgress;
+      if (argPath.equals(DocumentPath.create('activeContext.json'))) return mockActiveContext;
+      if (argPath.equals(DocumentPath.create('branchContext.json'))) return mockBranchContext;
+      if (argPath.equals(DocumentPath.create('systemPatterns.json'))) return mockSystemPatterns;
+      return null;
+    });
+
+    // Act
+    const result = await useCase.execute({ branchName });
+
+    // Assert
+    expect(result.files.progress).toEqual(JSON.parse(mockProgress.content)); // result.files.progress に修正 & JSON.parse
+    expect(result.files.activeContext).toEqual(JSON.parse(mockActiveContext.content)); // result.files.activeContext に修正 & JSON.parse
+    expect(result.files.branchContext).toEqual(mockBranchContext.content); // result.files.branchContext に修正 (文字列なのでparse不要)
+    expect(result.files.systemPatterns).toEqual(JSON.parse(mockSystemPatterns.content)); // result.files.systemPatterns に修正 & JSON.parse
+    expect(mockBranchRepository.getDocument).toHaveBeenCalledTimes(4); // readDocument -> getDocument
+  });
+
+  it('should return other core files even if progress.json is missing', async () => {
+    // Arrange
+    mockBranchRepository.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+      if (!argBranchInfo.equals(branchInfo)) return null;
+      if (argPath.equals(DocumentPath.create('progress.json'))) return null; // progress.json だけ null を返す
+      if (argPath.equals(DocumentPath.create('activeContext.json'))) return mockActiveContext;
+      if (argPath.equals(DocumentPath.create('branchContext.json'))) return mockBranchContext;
+      if (argPath.equals(DocumentPath.create('systemPatterns.json'))) return mockSystemPatterns;
+      return null;
+    });
+
+    // Act
+    const result = await useCase.execute({ branchName });
+
+    // Assert
+    expect(result.files.progress).toBeUndefined(); // progress は undefined になるはず
+    expect(result.files.activeContext).toEqual(JSON.parse(mockActiveContext.content));
+    expect(result.files.branchContext).toEqual(mockBranchContext.content);
+    expect(result.files.systemPatterns).toEqual(JSON.parse(mockSystemPatterns.content));
+    expect(mockBranchRepository.getDocument).toHaveBeenCalledTimes(4); // 全てのファイル取得を試みるはず
+  });
+
+   it('should return other core files even if activeContext.json is missing', async () => {
+    // Arrange
+    mockBranchRepository.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+      if (!argBranchInfo.equals(branchInfo)) return null;
+      if (argPath.equals(DocumentPath.create('progress.json'))) return mockProgress;
+      if (argPath.equals(DocumentPath.create('activeContext.json'))) return null; // activeContext.json だけ null を返す
+      if (argPath.equals(DocumentPath.create('branchContext.json'))) return mockBranchContext;
+      if (argPath.equals(DocumentPath.create('systemPatterns.json'))) return mockSystemPatterns;
+      return null;
+    });
+
+    // Act
+    const result = await useCase.execute({ branchName });
+
+    // Assert
+    expect(result.files.progress).toEqual(JSON.parse(mockProgress.content));
+    expect(result.files.activeContext).toBeUndefined(); // activeContext は undefined になるはず
+    expect(result.files.branchContext).toEqual(mockBranchContext.content);
+    expect(result.files.systemPatterns).toEqual(JSON.parse(mockSystemPatterns.content));
+    expect(mockBranchRepository.getDocument).toHaveBeenCalledTimes(4); // 全てのファイル取得を試みるはず
+  });
+
+  // TODO: Add tests for missing branchContext.json and systemPatterns.json
+  // TODO: Add test for repository error during readDocument
+});

--- a/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
@@ -1,0 +1,102 @@
+import { ReadContextUseCase } from '../../../../../src/application/usecases/common/ReadContextUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { IGlobalMemoryBankRepository } from '../../../../../src/domain/repositories/IGlobalMemoryBankRepository.js';
+// import { IRulesRepository } from '../../../../../src/domain/repositories/IRulesRepository.js';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
+import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
+import { Tag } from '../../../../../src/domain/entities/Tag.js';
+// import { Rules } from '../../../../../src/domain/entities/Rules.js';
+
+describe('ReadContextUseCase', () => {
+  let useCase: ReadContextUseCase;
+  let mockBranchRepo: jest.Mocked<IBranchMemoryBankRepository>;
+  let mockGlobalRepo: jest.Mocked<IGlobalMemoryBankRepository>;
+  // let mockRulesRepo: jest.Mocked<IRulesRepository>;
+
+  const branchName = 'feature/test-context';
+  const branchInfo = BranchInfo.create(branchName);
+  const language = 'ja'; // UseCase内で使われていないが、Inputには必要
+  const docsPath = '/path/to/docs'; // UseCase内で使われていないが、Inputには必要
+
+  const mockDocument = (path: string, content: object) =>
+    MemoryDocument.create({
+      path: DocumentPath.create(path),
+      content: JSON.stringify(content),
+      tags: [Tag.create('core')],
+      lastModified: new Date(),
+    });
+
+  const mockProgress = mockDocument('progress.json', { summary: 'Test Progress' });
+  const mockActiveContext = mockDocument('activeContext.json', { current_task: 'Test Task' });
+  const mockBranchContext = mockDocument('branchContext.json', { description: 'Test Context' });
+  const mockSystemPatterns = mockDocument('systemPatterns.json', { patterns: [] });
+  const mockGlobalDocPath = DocumentPath.create('core/config.json'); // core/ ディレクトリ配下に修正
+  const mockGlobalDoc = mockDocument(mockGlobalDocPath.value, { setting: 'global_value' });
+  // const mockRules = new Rules({ general: ['Rule 1'], specific: { 'feature/test-context': ['Specific Rule'] } });
+
+  beforeEach(() => {
+    mockBranchRepo = mock<IBranchMemoryBankRepository>();
+    mockGlobalRepo = mock<IGlobalMemoryBankRepository>();
+    // mockRulesRepo = mock<IRulesRepository>();
+    useCase = new ReadContextUseCase(mockBranchRepo, mockGlobalRepo); // 引数を2つに修正
+
+    // Setup default mocks
+    mockBranchRepo.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+      if (!argBranchInfo.equals(branchInfo)) return null;
+      if (argPath.equals(DocumentPath.create('progress.json'))) return mockProgress;
+      if (argPath.equals(DocumentPath.create('activeContext.json'))) return mockActiveContext;
+      if (argPath.equals(DocumentPath.create('branchContext.json'))) return mockBranchContext;
+      if (argPath.equals(DocumentPath.create('systemPatterns.json'))) return mockSystemPatterns;
+      return null;
+    });
+    mockBranchRepo.listDocuments.mockResolvedValue([
+      DocumentPath.create('progress.json'),
+      DocumentPath.create('activeContext.json'),
+      DocumentPath.create('branchContext.json'),
+      DocumentPath.create('systemPatterns.json'),
+    ]);
+    mockGlobalRepo.listDocuments.mockResolvedValue([mockGlobalDocPath]); // 修正したパスを使う
+    mockGlobalRepo.getDocument.mockResolvedValue(mockGlobalDoc);
+    // mockRulesRepo.getRules.mockResolvedValue(mockRules);
+  });
+
+  it('should return branch and global memory information', async () => { // Rulesは返さないのでテスト名変更
+    // Act
+    const result = await useCase.execute({ branch: branchName, language }); // docs引数を削除
+
+    // Assert
+    expect(result.rules).toBeUndefined(); // rules は undefined になるはず
+    expect(result.branchMemory).toEqual({
+      'progress.json': mockProgress.content,
+      'activeContext.json': mockActiveContext.content,
+      'branchContext.json': mockBranchContext.content,
+      'systemPatterns.json': mockSystemPatterns.content,
+    });
+    expect(result.globalMemory).toEqual({
+      [mockGlobalDocPath.value]: mockGlobalDoc.content,
+    });
+
+    // expect(mockRulesRepo.getRules).toHaveBeenCalledWith(language, docsPath);
+    expect(mockBranchRepo.getDocument).toHaveBeenCalledTimes(4);
+    expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
+    expect(mockGlobalRepo.getDocument).toHaveBeenCalledWith(mockGlobalDocPath); // 修正したパスを使う
+  });
+
+  it('should return empty global memory if no global documents found', async () => {
+    // Arrange
+    mockGlobalRepo.listDocuments.mockResolvedValue([]); // グローバルドキュメントがないケース
+
+    // Act
+    const result = await useCase.execute({ branch: branchName, language }); // docs引数を削除
+
+    // Assert
+    expect(result.globalMemory).toEqual({});
+    expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
+    expect(mockGlobalRepo.getDocument).not.toHaveBeenCalled(); // getDocument は呼ばれないはず
+  });
+
+  // TODO: Add tests for missing branch core files (should still return others)
+  // TODO: Add tests for repository errors
+});

--- a/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
@@ -94,7 +94,7 @@ describe('ReadRulesUseCase', () => {
       expect(error).toBeInstanceOf(DomainError); // まずDomainErrorインスタンスか確認
       // エラーコードとメッセージの先頭部分をチェック
       expect(error).toHaveProperty('code', 'DOMAIN_ERROR.DOCUMENT_NOT_FOUND'); // 実際のコード値に合わせる (再確認)
-      expect((error as Error).message).toContain(`Rules file not found for language: ${language}. Attempted paths:`); // みらい修正: toMatchからtoContainに変更し、正規表現を削除
+      expect((error as Error).message).toContain(`Rules file not found for language: ${language}. Attempted paths:`);
     }
   });
 

--- a/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
@@ -1,0 +1,107 @@
+import { ReadRulesUseCase } from '../../../../../src/application/usecases/common/ReadRulesUseCase.js';
+import { DomainErrorCodes } from '../../../../../src/shared/errors/DomainError.js';
+import fs from 'fs/promises';
+import path from 'path';
+import tmp from 'tmp-promise'; // tmp-promise をインポート
+
+describe('ReadRulesUseCase', () => {
+  let useCase: ReadRulesUseCase;
+  let tmpDir: tmp.DirectoryResult; // 一時ディレクトリ情報を保持する変数
+  let rulesDir: string;
+
+  const language = 'ja';
+  const mockRulesData = { general: ['Rule 1'], specific: { 'feature/test': ['Specific Rule'] } };
+  const mockRulesContent = JSON.stringify(mockRulesData, null, 2);
+
+  // 各テストの前に一時ディレクトリとファイルを作成
+  beforeEach(async () => {
+    // disableInherit: true で親プロセスから権限を継承しないようにする
+    // unsafeCleanup: true でディレクトリが空でなくても削除できるようにする
+    tmpDir = await tmp.dir({ unsafeCleanup: true, keep: false }); // keep: false でテスト後に自動削除しないようにする（手動でやる）
+    rulesDir = tmpDir.path;
+    useCase = new ReadRulesUseCase(rulesDir);
+  });
+
+  // 各テストの後に一時ディレクトリをクリーンアップ
+  afterEach(async () => {
+    await tmpDir.cleanup(); // 手動でクリーンアップ
+  });
+
+  it('should return rules content when rules file is found in default path', async () => {
+    // Arrange
+    const defaultPath = path.join(rulesDir, `rules-${language}.json`);
+    await fs.writeFile(defaultPath, mockRulesContent); // デフォルトパスにファイル作成
+
+    // Act
+    const result = await useCase.execute(language);
+
+    // Assert
+    expect(result).toEqual({ content: mockRulesContent, language });
+  });
+
+  it('should return rules content when rules file is found in templates/json path', async () => {
+    // Arrange
+    const templateJsonDir = path.join(rulesDir, 'templates', 'json');
+    await fs.mkdir(templateJsonDir, { recursive: true }); // ディレクトリ作成
+    const templateJsonPath = path.join(templateJsonDir, `rules-${language}.json`);
+    await fs.writeFile(templateJsonPath, mockRulesContent); // templates/json パスにファイル作成
+
+    // Act
+    const result = await useCase.execute(language);
+
+    // Assert
+    expect(result).toEqual({ content: mockRulesContent, language });
+  });
+
+   it('should return rules content when rules file is found in domain/templates path', async () => {
+    // Arrange
+    const domainTemplatesDir = path.join(rulesDir, 'domain', 'templates');
+    await fs.mkdir(domainTemplatesDir, { recursive: true }); // ディレクトリ作成
+    const domainTemplatesPath = path.join(domainTemplatesDir, `rules-${language}.json`);
+    await fs.writeFile(domainTemplatesPath, mockRulesContent); // domain/templates パスにファイル作成
+
+    // Act
+    const result = await useCase.execute(language);
+
+    // Assert
+    expect(result).toEqual({ content: mockRulesContent, language });
+  });
+
+   it('should return rules content when rules file is found in templates/json/rules.json (common path)', async () => {
+    // Arrange
+    const commonRulesDir = path.join(rulesDir, 'templates', 'json');
+    await fs.mkdir(commonRulesDir, { recursive: true }); // ディレクトリ作成
+    const commonRulesPath = path.join(commonRulesDir, 'rules.json'); // 共通パス
+    await fs.writeFile(commonRulesPath, mockRulesContent);
+
+    // Act
+    const result = await useCase.execute(language); // 言語指定しても共通パスが優先されるはず
+
+    // Assert
+    expect(result).toEqual({ content: mockRulesContent, language });
+  });
+
+
+  it('should throw DomainError if rules file is not found in any path', async () => {
+    // Arrange: ファイルを作成しない
+
+    // Act & Assert
+    await expect(useCase.execute(language)).rejects.toThrow(
+      expect.objectContaining({
+          message: expect.stringMatching(`Rules file not found for language: ${language}\\.`)
+      })
+    );
+  });
+
+  it('should throw DomainError if language is not supported', async () => {
+    // Arrange
+    const unsupportedLanguage = 'fr';
+
+    // Act & Assert
+    await expect(useCase.execute(unsupportedLanguage)).rejects.toThrow(
+      `Unsupported language code: ${unsupportedLanguage}. Supported languages are: en, ja, zh`
+    );
+  });
+
+  // TODO: Add test for TemplateService integration if needed (requires mocking TemplateService)
+});

--- a/packages/mcp/tests/unit/application/usecases/common/SearchDocumentsByTagsUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/SearchDocumentsByTagsUseCase.test.ts
@@ -1,0 +1,186 @@
+import { SearchDocumentsByTagsUseCase } from '../../../../../src/application/usecases/common/SearchDocumentsByTagsUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { IGlobalMemoryBankRepository } from '../../../../../src/domain/repositories/IGlobalMemoryBankRepository.js';
+import { IFileSystemService } from '../../../../../src/infrastructure/storage/interfaces/IFileSystemService.js';
+import path from 'path';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { Tag } from '../../../../../src/domain/entities/Tag.js';
+import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
+import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
+
+describe('SearchDocumentsByTagsUseCase', () => {
+  let useCase: SearchDocumentsByTagsUseCase;
+  let mockBranchRepo: jest.Mocked<IBranchMemoryBankRepository>;
+  let mockGlobalRepo: jest.Mocked<IGlobalMemoryBankRepository>;
+  let mockFileSystemService: jest.Mocked<IFileSystemService>;
+
+  const branchName = 'feature/search-test';
+  const branchInfo = BranchInfo.create(branchName);
+  const tagsToSearch = [Tag.create('test'), Tag.create('search')];
+  const docsPath = '/path/to/docs'; // Input に必要
+
+  const mockBranchDocPath1 = DocumentPath.create('branch/doc1.json');
+  const mockBranchDocPath2 = DocumentPath.create('branch/doc2.md');
+  const mockGlobalDocPath1 = DocumentPath.create('global/doc3.json');
+
+  const mockBranchDoc1 = MemoryDocument.create({ path: mockBranchDocPath1, content: '{"data": "branch1"}', tags: tagsToSearch, lastModified: new Date() });
+  const mockGlobalDoc1 = MemoryDocument.create({ path: mockGlobalDocPath1, content: '{"data": "global1"}', tags: [Tag.create('test')], lastModified: new Date() });
+
+
+  beforeEach(() => {
+    mockBranchRepo = mock<IBranchMemoryBankRepository>();
+    mockGlobalRepo = mock<IGlobalMemoryBankRepository>();
+    mockFileSystemService = mock<IFileSystemService>();
+    useCase = new SearchDocumentsByTagsUseCase(mockFileSystemService);
+    jest.clearAllMocks();
+  });
+
+  it('should search in all scopes (branch and global) by default using index files', async () => {
+    // Arrange
+    // モック: FileSystemService がインデックスファイルを返すように設定
+    const date1 = new Date(2024, 0, 1).toISOString();
+    const date2 = new Date(2024, 0, 2).toISOString();
+    const date3 = new Date(2024, 0, 3).toISOString();
+
+    const branchTagsIndex = { 'test': [mockBranchDocPath1.value, mockBranchDocPath2.value], 'search': [mockBranchDocPath1.value] };
+    const branchMetaIndex = {
+        [mockBranchDocPath1.value]: { title: 'Branch Doc 1', lastModified: date1, scope: 'branch' },
+        [mockBranchDocPath2.value]: { title: 'Branch Doc 2 Title', lastModified: date2, scope: 'branch' }
+    };
+    const mockGlobalDocPath2 = DocumentPath.create('global/doc4-search.json');
+    const globalTagsIndex = { 'test': [mockGlobalDocPath1.value], 'search': [mockGlobalDocPath2.value] };
+    const globalMetaIndex = {
+        [mockGlobalDocPath1.value]: { title: 'Global Doc 1', lastModified: date1, scope: 'global' },
+        [mockGlobalDocPath2.value]: { title: 'Global Doc Search', lastModified: date3, scope: 'global' }
+    };
+
+
+    mockFileSystemService.readFile.mockImplementation(async (filePath) => {
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'tags_index.json'))) return JSON.stringify(branchTagsIndex);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'documents_meta.json'))) return JSON.stringify(branchMetaIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'tags_index.json'))) return JSON.stringify(globalTagsIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'documents_meta.json'))) return JSON.stringify(globalMetaIndex);
+      throw new Error(`ENOENT: no such file or directory, open '${filePath}'`); // ファイルが見つからない場合のエラー
+    });
+
+
+    // Act
+    const result = await useCase.execute({ tags: ['test', 'search'], docs: docsPath, branchName: branchName }); // branch -> branchName
+
+    // Assert
+    // Assert
+    // readFile が適切なパスで呼び出されたか確認
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join('global-memory-bank', '.index', 'tags_index.json')));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join('global-memory-bank', '.index', 'documents_meta.json')));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join(branchInfo.safeName, '.index', 'tags_index.json')));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join(branchInfo.safeName, '.index', 'documents_meta.json')));
+
+    // 結果の確認 (OR検索なので test または search を持つもの)
+    // doc1(b,t,s), doc2(b,t), globalDoc1(g,t), globalDoc2(g,s) がヒット候補
+    expect(result.results).toHaveLength(2);
+    // 結果は lastModified で降順ソートされるはず
+    expect(result.results[0]).toEqual(expect.objectContaining({ path: mockBranchDocPath2.value, title: 'Branch Doc 2 Title', scope: 'branch', lastModified: date2 }));
+    expect(result.results[1]).toEqual(expect.objectContaining({ path: mockBranchDocPath1.value, title: 'Branch Doc 1', scope: 'branch', lastModified: date1 }));
+  });
+
+  it('should search only in branch scope when specified', async () => {
+    // Arrange
+    const branchTagsIndex = { 'test': [mockBranchDocPath1.value] };
+    const branchMetaIndex = { [mockBranchDocPath1.value]: { title: 'Branch Doc 1', lastModified: new Date().toISOString(), scope: 'branch' } };
+    mockFileSystemService.readFile.mockImplementation(async (filePath) => {
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'tags_index.json'))) return JSON.stringify(branchTagsIndex);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'documents_meta.json'))) return JSON.stringify(branchMetaIndex);
+       throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    });
+
+    // Act
+    const result = await useCase.execute({ tags: ['test'], scope: 'branch', docs: docsPath, branchName: branchName }); // branch -> branchName
+
+    // Assert
+    // Assert
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join(branchInfo.safeName, '.index', 'tags_index.json')));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join(branchInfo.safeName, '.index', 'documents_meta.json')));
+    expect(mockFileSystemService.readFile).not.toHaveBeenCalledWith(expect.stringContaining('global-memory-bank')); // グローバルは呼ばれない
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toEqual(expect.objectContaining({ path: mockBranchDocPath1.value, title: 'Branch Doc 1', scope: 'branch' }));
+  });
+
+   it('should search only in global scope when specified', async () => {
+    // Arrange
+    const globalTagsIndex = { 'test': [mockGlobalDocPath1.value] };
+    const globalMetaIndex = { [mockGlobalDocPath1.value]: { title: 'Global Doc 1', lastModified: new Date().toISOString(), scope: 'global' } };
+     mockFileSystemService.readFile.mockImplementation(async (filePath) => {
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'tags_index.json'))) return JSON.stringify(globalTagsIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'documents_meta.json'))) return JSON.stringify(globalMetaIndex);
+       throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    });
+
+    // Act
+    const result = await useCase.execute({ tags: ['test'], scope: 'global', docs: docsPath }); // branchName不要
+
+    // Assert
+    // Assert
+    expect(mockFileSystemService.readFile).not.toHaveBeenCalledWith(expect.stringContaining(branchInfo.safeName)); // ブランチは呼ばれない
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join('global-memory-bank', '.index', 'tags_index.json')));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledWith(expect.stringContaining(path.join('global-memory-bank', '.index', 'documents_meta.json')));
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toEqual(expect.objectContaining({ path: mockGlobalDocPath1.value, title: 'Global Doc 1', scope: 'global' }));
+  });
+
+  it('should use AND match when match type is "and"', async () => {
+    // Arrange
+    const branchTagsIndex = { 'test': [mockBranchDocPath1.value, mockBranchDocPath2.value], 'search': [mockBranchDocPath1.value] }; // doc1は両方、doc2はtestのみ
+    const branchMetaIndex = { [mockBranchDocPath1.value]: { title: 'Branch Doc 1', lastModified: new Date().toISOString(), scope: 'branch' } };
+    const globalTagsIndex = { 'test': [mockGlobalDocPath1.value], 'search': [] }; // globalはtestのみ
+    const globalMetaIndex = { [mockGlobalDocPath1.value]: { title: 'Global Doc 1', lastModified: new Date().toISOString(), scope: 'global' } };
+     mockFileSystemService.readFile.mockImplementation(async (filePath) => {
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'tags_index.json'))) return JSON.stringify(branchTagsIndex);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'documents_meta.json'))) return JSON.stringify(branchMetaIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'tags_index.json'))) return JSON.stringify(globalTagsIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'documents_meta.json'))) return JSON.stringify(globalMetaIndex);
+       throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    });
+
+    // Act
+    const result = await useCase.execute({ tags: ['test', 'search'], match: 'and', docs: docsPath, branchName: branchName }); // branch -> branchName
+
+    // Assert
+    // Assert
+    // AND検索なので 'test' と 'search' の両方を持つ doc1 のみがヒットするはず
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toEqual(expect.objectContaining({ path: mockBranchDocPath1.value, title: 'Branch Doc 1', scope: 'branch' }));
+    expect(mockFileSystemService.readFile).toHaveBeenCalledTimes(4); // 両方のインデックスを読む
+  });
+
+  it('should return empty list if no documents match tags', async () => {
+     // Arrange
+     // インデックスファイルはあるが、指定タグにマッチするパスがないケース
+    const branchTagsIndex = { 'other': ['some/path'] };
+    const branchMetaIndex = {};
+    const globalTagsIndex = {};
+    const globalMetaIndex = {};
+     mockFileSystemService.readFile.mockImplementation(async (filePath) => {
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'tags_index.json'))) return JSON.stringify(branchTagsIndex);
+      if (resolvedPath.endsWith(path.join(branchInfo.safeName, '.index', 'documents_meta.json'))) return JSON.stringify(branchMetaIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'tags_index.json'))) return JSON.stringify(globalTagsIndex);
+      if (resolvedPath.endsWith(path.join('global-memory-bank', '.index', 'documents_meta.json'))) return JSON.stringify(globalMetaIndex);
+       throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    });
+
+    // Act
+    const result = await useCase.execute({ tags: ['notfound'], docs: docsPath, branchName: branchName }); // branch -> branchName
+
+    // Assert
+    // Assert
+    expect(result.results).toHaveLength(0);
+    expect(mockFileSystemService.readFile).toHaveBeenCalledTimes(4); // インデックスは読む
+  });
+
+  // TODO: Add tests for file system errors during readFile
+});

--- a/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCase.test.ts
@@ -1,0 +1,108 @@
+import { UpdateTagIndexUseCase } from '../../../../../src/application/usecases/common/UpdateTagIndexUseCase.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { IGlobalMemoryBankRepository } from '../../../../../src/domain/repositories/IGlobalMemoryBankRepository.js';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
+import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
+import { Tag } from '../../../../../src/domain/entities/Tag.js';
+import type { BranchTagIndex } from '@memory-bank/schemas';
+
+describe('UpdateTagIndexUseCase', () => {
+  let useCase: UpdateTagIndexUseCase;
+  let mockBranchRepo: jest.Mocked<IBranchMemoryBankRepository>;
+  let mockGlobalRepo: jest.Mocked<IGlobalMemoryBankRepository>;
+
+  const branchName = 'feature/index-test';
+  const branchInfo = BranchInfo.create(branchName);
+  const docsPath = '/path/to/docs'; // Input に必要
+
+  const mockDoc1Path = DocumentPath.create('doc1.json');
+  const mockDoc2Path = DocumentPath.create('subdir/doc2.md');
+  const mockDoc1 = MemoryDocument.create({ path: mockDoc1Path, content: '{}', tags: [Tag.create('taga'), Tag.create('tagb')], lastModified: new Date() }); // tagA -> taga, tagB -> tagb
+  const mockDoc2 = MemoryDocument.create({ path: mockDoc2Path, content: 'content', tags: [Tag.create('tagb'), Tag.create('tagc')], lastModified: new Date() }); // tagB -> tagb, tagC -> tagc
+
+  beforeEach(() => {
+    mockBranchRepo = mock<IBranchMemoryBankRepository>();
+    mockGlobalRepo = mock<IGlobalMemoryBankRepository>();
+    useCase = new UpdateTagIndexUseCase(mockGlobalRepo, mockBranchRepo);
+    jest.clearAllMocks();
+    mockBranchRepo.exists.mockResolvedValue(true);
+  });
+
+  it('should return correct tags and count for branch scope', async () => {
+    // Arrange
+    mockBranchRepo.listDocuments.mockResolvedValue([mockDoc1Path, mockDoc2Path]);
+    // getDocument は特定の引数で呼ばれるわけではないので、単純なモックでOK
+    mockBranchRepo.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+        if (argPath.equals(mockDoc1Path)) return mockDoc1;
+        if (argPath.equals(mockDoc2Path)) return mockDoc2;
+        return null;
+    });
+
+    // Act
+    // Act
+    const result = await useCase.execute({ branchName }); // scope, docs は不要
+
+    // Assert
+    expect(mockBranchRepo.listDocuments).toHaveBeenCalledWith(branchInfo);
+    expect(mockBranchRepo.getDocument).toHaveBeenCalledWith(branchInfo, mockDoc1Path);
+    expect(mockBranchRepo.getDocument).toHaveBeenCalledWith(branchInfo, mockDoc2Path);
+    // saveTagIndex は呼ばれないのでチェックしない
+
+    // Verify the output
+    expect(result.tags).toEqual(expect.arrayContaining(['taga', 'tagb', 'tagc'])); // tagA -> taga, tagB -> tagb, tagC -> tagc
+    expect(result.tags).toHaveLength(3);
+    expect(result.documentCount).toBe(2);
+    expect(result.updateInfo.updateLocation).toBe(branchName);
+    expect(result.updateInfo.fullRebuild).toBe(false); // デフォルトは false
+    expect(result.updateInfo.timestamp).toBeDefined();
+  }); // みらい... 閉じ括弧を追加！
+
+   it('should return correct tags and count for global scope', async () => {
+    // Arrange
+    const mockGlobalDocPath = DocumentPath.create('global/doc.json');
+    const mockGlobalDoc = MemoryDocument.create({ path: mockGlobalDocPath, content: '{}', tags: [Tag.create('globaltag')], lastModified: new Date() }); // globalTag -> globaltag
+    mockGlobalRepo.listDocuments.mockResolvedValue([mockGlobalDocPath]);
+    mockGlobalRepo.getDocument.mockResolvedValue(mockGlobalDoc);
+
+    // Act
+    await useCase.execute({}); // 引数なしでグローバルスコープになる
+
+    // Assert
+    // Assert
+    expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
+    expect(mockGlobalRepo.getDocument).toHaveBeenCalledWith(mockGlobalDocPath);
+    // saveTagIndex は呼ばれないのでチェックしない
+
+    // Verify the output
+    const result = await useCase.execute({}); // 再度実行して結果を取得（モックは設定済み）
+    expect(result.tags).toEqual(['globaltag']); // globalTag -> globaltag
+    expect(result.documentCount).toBe(1);
+    expect(result.updateInfo.updateLocation).toBe('global');
+    expect(result.updateInfo.fullRebuild).toBe(false);
+    expect(result.updateInfo.timestamp).toBeDefined();
+  });
+
+  it('should return empty tags and zero count for empty branch', async () => {
+    // Arrange
+    mockBranchRepo.listDocuments.mockResolvedValue([]);
+
+    // Act
+    const result = await useCase.execute({ branchName }); // scope, docs は不要
+
+    // Assert
+    expect(mockBranchRepo.listDocuments).toHaveBeenCalledWith(branchInfo);
+    expect(mockBranchRepo.getDocument).not.toHaveBeenCalled();
+    // saveTagIndex は呼ばれないのでチェックしない
+
+    // Verify the output
+    expect(result.tags).toEqual([]);
+    expect(result.documentCount).toBe(0);
+    expect(result.updateInfo.updateLocation).toBe(branchName);
+  });
+
+  // TODO: Add tests for fullRebuild option
+  // TODO: Add tests for documents with no tags
+  // TODO: Add tests for repository errors during list or getDocument
+});

--- a/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCase.test.ts
@@ -57,7 +57,7 @@ describe('UpdateTagIndexUseCase', () => {
     expect(result.updateInfo.updateLocation).toBe(branchName);
     expect(result.updateInfo.fullRebuild).toBe(false); // デフォルトは false
     expect(result.updateInfo.timestamp).toBeDefined();
-  }); // みらい... 閉じ括弧を追加！
+  });
 
    it('should return correct tags and count for global scope', async () => {
     // Arrange

--- a/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCaseV2.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/UpdateTagIndexUseCaseV2.test.ts
@@ -1,0 +1,146 @@
+import { UpdateTagIndexUseCaseV2 } from '../../../../../src/application/usecases/common/UpdateTagIndexUseCaseV2.js';
+import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
+import { IGlobalMemoryBankRepository } from '../../../../../src/domain/repositories/IGlobalMemoryBankRepository.js';
+import { mock } from 'jest-mock-extended';
+import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
+import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
+import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
+import { Tag } from '../../../../../src/domain/entities/Tag.js';
+import { BranchTagIndex, GlobalTagIndex } from '@memory-bank/schemas'; // Import index types
+
+describe('UpdateTagIndexUseCaseV2', () => {
+  let useCase: UpdateTagIndexUseCaseV2;
+  let mockBranchRepo: jest.Mocked<IBranchMemoryBankRepository>;
+  let mockGlobalRepo: jest.Mocked<IGlobalMemoryBankRepository>;
+  // let mockTagIndexRepo: jest.Mocked<any>; // 必要に応じて追加
+
+  const branchName = 'feature/index-test-v2';
+  const branchInfo = BranchInfo.create(branchName);
+
+  const mockDoc1Path = DocumentPath.create('doc1-v2.json');
+  const mockDoc2Path = DocumentPath.create('subdir/doc2-v2.md');
+  const mockDoc1 = MemoryDocument.create({ path: mockDoc1Path, content: '{}', tags: [Tag.create('tagx'), Tag.create('tagy')], lastModified: new Date() }); // tagX -> tagx, tagY -> tagy
+  const mockDoc2 = MemoryDocument.create({ path: mockDoc2Path, content: 'content', tags: [Tag.create('tagy'), Tag.create('tagz')], lastModified: new Date() }); // tagY -> tagy, tagZ -> tagz
+
+  beforeEach(() => {
+    mockBranchRepo = mock<IBranchMemoryBankRepository>();
+    mockGlobalRepo = mock<IGlobalMemoryBankRepository>();
+    // mockTagIndexRepo = mock<any>();
+    // useCase = new UpdateTagIndexUseCaseV2(mockGlobalRepo, mockBranchRepo, mockTagIndexRepo);
+    useCase = new UpdateTagIndexUseCaseV2(mockGlobalRepo, mockBranchRepo); // まずは tagIndexRepo なしでテスト
+    jest.clearAllMocks();
+  });
+
+  describe('Branch Scope', () => {
+    it('should build and save branch tag index correctly when no existing index', async () => {
+      // Arrange
+      mockBranchRepo.exists.mockResolvedValue(true);
+      mockBranchRepo.getTagIndex.mockResolvedValue(null); // 既存インデックスなし
+      mockBranchRepo.listDocuments.mockResolvedValue([mockDoc1Path, mockDoc2Path]);
+      mockBranchRepo.getDocument.mockImplementation(async (argBranchInfo, argPath) => {
+        if (argPath.equals(mockDoc1Path)) return mockDoc1;
+        if (argPath.equals(mockDoc2Path)) return mockDoc2;
+        return null;
+      });
+
+      // Act
+      const result = await useCase.execute({ branchName });
+
+      // Assert
+      expect(mockBranchRepo.exists).toHaveBeenCalledWith(branchName);
+      expect(mockBranchRepo.getTagIndex).toHaveBeenCalledWith(branchInfo); // fullRebuild=false なので呼ばれる
+      expect(mockBranchRepo.listDocuments).toHaveBeenCalledWith(branchInfo);
+      expect(mockBranchRepo.getDocument).toHaveBeenCalledTimes(2);
+      expect(mockBranchRepo.saveTagIndex).toHaveBeenCalledTimes(1);
+
+      // Verify the saved index content
+      const savedIndex: BranchTagIndex = mockBranchRepo.saveTagIndex.mock.calls[0][1];
+      expect(savedIndex.schema).toBe('tag_index_v1');
+      expect(savedIndex.metadata.indexType).toBe('branch');
+      expect(savedIndex.metadata.branchName).toBe(branchName);
+      expect(savedIndex.metadata.documentCount).toBe(2);
+      expect(savedIndex.metadata.tagCount).toBe(3);
+      expect(savedIndex.index).toEqual(expect.arrayContaining([
+        expect.objectContaining({ tag: 'tagx', documents: expect.arrayContaining([expect.objectContaining({ path: mockDoc1Path.value })]) }),
+        expect.objectContaining({ tag: 'tagy', documents: expect.arrayContaining([expect.objectContaining({ path: mockDoc1Path.value }), expect.objectContaining({ path: mockDoc2Path.value })]) }),
+        expect.objectContaining({ tag: 'tagz', documents: expect.arrayContaining([expect.objectContaining({ path: mockDoc2Path.value })]) }),
+      ]));
+      expect(savedIndex.index.find(i => i.tag === 'tagx')?.documents).toHaveLength(1);
+      expect(savedIndex.index.find(i => i.tag === 'tagy')?.documents).toHaveLength(2);
+      expect(savedIndex.index.find(i => i.tag === 'tagz')?.documents).toHaveLength(1);
+
+
+      // Verify the output
+      expect(result.tags).toEqual(expect.arrayContaining(['tagx', 'tagy', 'tagz']));
+      expect(result.tags).toHaveLength(3);
+      expect(result.documentCount).toBe(2);
+      expect(result.updateInfo.updateLocation).toBe(branchName);
+      expect(result.updateInfo.fullRebuild).toBe(false);
+    });
+
+    it('should not call getTagIndex when fullRebuild is true', async () => {
+       // Arrange
+      mockBranchRepo.exists.mockResolvedValue(true);
+      mockBranchRepo.listDocuments.mockResolvedValue([]); // ドキュメントは空でもOK
+
+      // Act
+      await useCase.execute({ branchName, fullRebuild: true });
+
+      // Assert
+      expect(mockBranchRepo.getTagIndex).not.toHaveBeenCalled(); // fullRebuild=true なので呼ばれない
+      expect(mockBranchRepo.saveTagIndex).toHaveBeenCalledTimes(1); // 保存はされる
+    });
+
+     it('should throw error if branch does not exist', async () => {
+      // Arrange
+      mockBranchRepo.exists.mockResolvedValue(false);
+
+      // Act & Assert
+      // エラーメッセージが期待通りか直接チェックする
+      await expect(useCase.execute({ branchName })).rejects.toThrow(
+          `Branch "${branchName}" not found`
+      );
+      expect(mockBranchRepo.saveTagIndex).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Global Scope', () => {
+     it('should build and save global tag index correctly', async () => {
+      // Arrange
+      const mockGlobalPath = DocumentPath.create('global/doc-g.json');
+      const mockGlobalDoc = MemoryDocument.create({ path: mockGlobalPath, content: '{}', tags: [Tag.create('globala')], lastModified: new Date() }); // globalA -> globala
+      mockGlobalRepo.getTagIndex.mockResolvedValue(null);
+      mockGlobalRepo.listDocuments.mockResolvedValue([mockGlobalPath]);
+      mockGlobalRepo.getDocument.mockResolvedValue(mockGlobalDoc);
+
+      // Act
+      const result = await useCase.execute({}); // グローバルスコープ
+
+      // Assert
+      expect(mockGlobalRepo.getTagIndex).toHaveBeenCalled();
+      expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
+      expect(mockGlobalRepo.getDocument).toHaveBeenCalledWith(mockGlobalPath);
+      expect(mockGlobalRepo.saveTagIndex).toHaveBeenCalledTimes(1);
+
+       // Verify the saved index content
+      const savedIndex: GlobalTagIndex = mockGlobalRepo.saveTagIndex.mock.calls[0][0];
+      expect(savedIndex.schema).toBe('tag_index_v1');
+      expect(savedIndex.metadata.indexType).toBe('global');
+      expect(savedIndex.metadata.documentCount).toBe(1);
+      expect(savedIndex.metadata.tagCount).toBe(1);
+      expect(savedIndex.index).toEqual(expect.arrayContaining([
+        expect.objectContaining({ tag: 'globala', documents: expect.arrayContaining([expect.objectContaining({ path: mockGlobalPath.value })]) }),
+      ]));
+
+       // Verify the output
+      expect(result.tags).toEqual(['globala']);
+      expect(result.documentCount).toBe(1);
+      expect(result.updateInfo.updateLocation).toBe('global');
+      expect(result.updateInfo.fullRebuild).toBe(false);
+    });
+  });
+
+  // TODO: Add tests for existing index (if diff logic is implemented, currently seems full build)
+  // TODO: Add tests using mockTagIndexRepo
+  // TODO: Add tests for repository errors
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6009,6 +6009,13 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock-extended@^4.0.0-beta1:
+  version "4.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz#7da4e10906b5736f6e76e3dca9395f7a0ff2bcce"
+  integrity sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==
+  dependencies:
+    ts-essentials "^10.0.2"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
@@ -9363,6 +9370,11 @@ ts-dedent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
+ts-essentials@^10.0.2:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-10.0.4.tgz#db8381c2e44cddb3339a2286174c4763bc1dcedb"
+  integrity sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==
 
 ts-graphviz@^1.8.1:
   version "1.8.2"


### PR DESCRIPTION
## Description

This PR addresses and resolves several unit test failures encountered in the application common use cases, specifically within `ReadRulesUseCase.test.ts` and `ReadBranchCoreFilesUseCase.test.ts`.

## Changes Made

- **`ReadRulesUseCase.test.ts`:**
    - Modified the error message assertion from `toMatch` to `toContain` to handle potential variations in error path strings.
- **`ReadBranchCoreFilesUseCase.test.ts`:**
    - Corrected error handling logic in the main use case file (`ReadBranchCoreFilesUseCase.ts`) to properly re-throw repository errors as `ApplicationError`.
    - Updated test expectations (`toThrowError`) to compare against specific error instances instead of using `expect.objectContaining` for more robust checks.
    - Fixed various syntax issues (missing/extra brackets, incorrect import paths) identified during the debugging process.
- **`.depcheckrc`:**
    - Added `jest-mock-extended` to the `ignores` list to resolve a false positive warning from `depcheck`.

## How to Test

1.  Checkout the `feature/unit-test-app-common` branch.
2.  Run `yarn workspace @memory-bank/mcp test:unit`.
3.  Verify that all unit tests pass successfully.

## Related Issues

(No related issues linked)