### PR TITLE
Fix Timestamp Comparison in Unit Tests (#124)

### DIFF
--- a/packages/mcp/tests/unit/domain/entities/BranchInfo.test.ts
+++ b/packages/mcp/tests/unit/domain/entities/BranchInfo.test.ts
@@ -28,12 +28,16 @@ describe('BranchInfo Unit Tests', () => {
 
     it('should throw an error for a branch name without a prefix', () => {
       const invalidBranchName = 'my-cool-feature';
-      expect(() => BranchInfo.create(invalidBranchName)).toThrow(
-        new DomainError(
-          DomainErrorCodes.INVALID_BRANCH_NAME,
-          'Branch name must include a namespace prefix with slash (e.g. "feature/my-branch")'
-        )
-      );
+      const expectedMessage = 'Branch name must include a namespace prefix with slash (e.g. "feature/my-branch")';
+      const expectedCode = "DOMAIN_ERROR.INVALID_BRANCH_NAME"; // Use the actual string value including prefix
+      try {
+        BranchInfo.create(invalidBranchName);
+        throw new Error('Expected DomainError but no error was thrown.'); // Should not reach here
+      } catch (error) {
+        expect(error).toBeInstanceOf(DomainError);
+        expect((error as DomainError).message).toBe(expectedMessage);
+        expect((error as DomainError).code).toBe(expectedCode);
+      }
     });
 
      it('should throw an error for a branch name with only a prefix', () => {


### PR DESCRIPTION
# Pull Request: Fix Timestamp Comparison in Unit Tests (#124)

## Description

This PR addresses issue #124 by fixing a failing unit test in `BranchInfo.test.ts`. The test was failing in CI environments due to subtle differences in timestamps when comparing error object instances directly.

## Changes Made

- Modified the test case `should throw an error for a branch name without a prefix` in `packages/mcp/tests/unit/domain/entities/BranchInfo.test.ts`.
- Changed the assertion from comparing the entire error instance (`toThrow(new DomainError(...))`) to checking the error type (`toBeInstanceOf(DomainError)`) and error code (`(error as DomainError).code`). This avoids issues caused by timestamp mismatches.
- Verified that no other unit tests were using direct error instance comparison that could lead to similar issues.

## Related Issue

Fixes #124