### PR TITLE
feat: Auto-parse JSON responses and format on write (#112)

### DIFF
--- a/docs/branch-memory-bank/fix-issues-112/activeContext.json
+++ b/docs/branch-memory-bank/fix-issues-112/activeContext.json
@@ -1,0 +1,17 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issues-112-active-context",
+    "title": "Active Context for fix/issues-112",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [],
+    "createdAt": "2025-04-08T05:21:35.543Z",
+    "lastModified": "2025-04-08T05:21:35.543Z"
+  },
+  "content": {
+    "current_task": "Initial active context for branch: fix/issues-112",
+    "relevant_files": [],
+    "recent_decisions": []
+  }
+}

--- a/docs/branch-memory-bank/fix-issues-112/branchContext.json
+++ b/docs/branch-memory-bank/fix-issues-112/branchContext.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issues-112-context",
+    "title": "Branch Context for fix/issues-112",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [],
+    "createdAt": "2025-04-08T05:21:35.543Z",
+    "lastModified": "2025-04-08T05:21:35.543Z"
+  },
+  "content": {
+    "description": "Context for branch: fix/issues-112"
+  }
+}

--- a/docs/branch-memory-bank/fix-issues-112/feature-issue-112-auto-parse-json/plan.md
+++ b/docs/branch-memory-bank/fix-issues-112/feature-issue-112-auto-parse-json/plan.md
@@ -1,0 +1,38 @@
+# Issue #112: Auto-parse JSON responses and format on write
+
+## Objective
+Automatically parse JSON content when reading from memory banks and format JSON content when writing.
+
+## Agreed Policy
+
+1.  **On Read (`Read*UseCase`):**
+    *   Attempt `JSON.parse()` on the file content.
+    *   If successful, return the parsed JavaScript **object**.
+    *   If parsing fails (not JSON or invalid JSON), return the content as a **string**.
+    *   **Do not modify the original file on read.**
+    *   The return type will be `string | object`.
+2.  **On Write (`Write*UseCase`):**
+    *   Check the type of the `content` argument.
+    *   If `content` is an **object**, convert it to a formatted JSON string (`JSON.stringify(content, null, 2)`) before writing to the file.
+    *   If `content` is a **string**, write it to the file as is.
+    *   Ensure `patches` operations also result in formatted JSON if the final content is an object.
+
+## Implementation Steps (TDD Approach)
+
+1.  **Identify Affected Tests:** (Completed)
+    *   Integration Tests:
+        *   `packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts`
+        *   `packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts`
+        *   `packages/mcp/tests/integration/usecase/ReadGlobalDocumentUseCase.integration.test.ts`
+        *   `packages/mcp/tests/integration/usecase/WriteBranchDocumentUseCase.integration.test.ts`
+        *   `packages/mcp/tests/integration/usecase/WriteGlobalDocumentUseCase.integration.test.ts`
+    *   Unit Tests:
+        *   `packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts`
+        *   `packages/mcp/tests/unit/application/usecases/branch/ReadBranchDocumentUseCase.test.ts`
+        *   `packages/mcp/tests/unit/application/usecases/global/ReadGlobalDocumentUseCase.test.ts`
+        *   `packages/mcp/tests/unit/application/usecases/branch/WriteBranchDocumentUseCase.test.ts`
+        *   `packages/mcp/tests/unit/application/usecases/global/WriteGlobalDocumentUseCase.test.ts`
+2.  **Modify Tests & Confirm Red:** Update assertions in the identified test files to match the new expected behavior. Run tests to confirm they fail (Red).
+3.  **Implement Changes:** Modify the use case implementations (`Read*UseCase`, `Write*UseCase`) according to the policy.
+4.  **Confirm Green:** Run tests again to confirm they pass (Green).
+5.  **Update Documentation:** Update any relevant documentation (e.g., tool descriptions, READMEs) to reflect the changes.

--- a/docs/branch-memory-bank/fix-issues-112/progress.json
+++ b/docs/branch-memory-bank/fix-issues-112/progress.json
@@ -1,0 +1,19 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issues-112-progress",
+    "title": "Progress for fix/issues-112",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [],
+    "createdAt": "2025-04-08T05:21:35.543Z",
+    "lastModified": "2025-04-08T05:21:35.543Z"
+  },
+  "content": {
+    "summary": "Initial progress for branch: fix/issues-112",
+    "status": "initialized",
+    "steps": [],
+    "next_steps": [],
+    "findings": []
+  }
+}

--- a/docs/branch-memory-bank/fix-issues-112/systemPatterns.json
+++ b/docs/branch-memory-bank/fix-issues-112/systemPatterns.json
@@ -1,0 +1,15 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "fix-issues-112-system-patterns",
+    "title": "System Patterns for fix/issues-112",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [],
+    "createdAt": "2025-04-08T05:21:35.543Z",
+    "lastModified": "2025-04-08T05:21:35.543Z"
+  },
+  "content": {
+    "patterns": []
+  }
+}

--- a/docs/global-memory-bank/_global_index.json
+++ b/docs/global-memory-bank/_global_index.json
@@ -2,7 +2,7 @@
   "schema": "tag_index_v1",
   "metadata": {
     "indexType": "global",
-    "lastUpdated": "2025-04-07T09:01:36.341Z",
+    "lastUpdated": "2025-04-08T05:49:30.986Z",
     "documentCount": 38,
     "tagCount": 56
   },
@@ -11,13 +11,13 @@
       "tag": "project",
       "documents": [
         {
-          "id": "69c31818-61cb-43a0-88ec-d0920cb706be",
+          "id": "088858bf-a598-412f-b323-cfc19ec47697",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "580d4db5-7011-44e2-a398-00db37c82fc2",
+          "id": "152fb3fc-5f0a-4aee-99b5-97e035e786aa",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -28,85 +28,85 @@
       "tag": "documentation",
       "documents": [
         {
-          "id": "69c31818-61cb-43a0-88ec-d0920cb706be",
+          "id": "088858bf-a598-412f-b323-cfc19ec47697",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "c772f190-e4f4-46f1-ad03-38bbcef56ace",
+          "id": "ff7f0d34-0fa4-4138-9045-b3a3af093ffb",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "823b55b9-3a1b-443b-8dcd-169378d18852",
+          "id": "b8680798-2aca-4cae-9458-a8e663a4ea85",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "e3476503-a098-4e10-ad65-f39b4c323453",
+          "id": "dd5e2569-c0af-4c23-9c1c-fdc577ac52b2",
           "path": "04-guides/README.json",
           "title": "Guides Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "ac56482d-9528-4bc7-be58-a227b8af050c",
+          "id": "1e1544ff-deab-4978-abd9-51a4b24565df",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "6ef683c1-ee52-447c-b477-0a8c859123d6",
+          "id": "436b2003-522f-43b7-9d42-a69df9e649cf",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "cd6f2590-c557-42e6-b9af-f030729ce711",
+          "id": "c542e453-6645-4636-8df8-2edb0cd963f1",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "30000933-63e5-4d34-adbe-11ca5f602bad",
+          "id": "1bdf4fc0-e4db-4fe8-9cc1-163af12880d1",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "332b619c-d5bd-41f2-976c-140bfc1ad6f1",
+          "id": "799dc4cc-869b-4447-8475-27fd10fa72a8",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "324d7fd8-a16c-4a6e-baf2-1c9f9cb6df1a",
+          "id": "dcdbb227-4953-46a0-974b-72b90b19e167",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "3bca0b4b-8467-4fbb-9295-b8a2c61cc9de",
+          "id": "e527abf0-1ea7-4d0f-96c7-0c8b53640e4b",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "a57a7f72-c0e9-48b4-b4af-d495ba786773",
+          "id": "8b496b73-eb96-4d70-8fbe-a263fce4c3d8",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "31b25b6f-7dee-4b88-a1e6-ba47bdc02689",
+          "id": "d7c30e9d-59d4-463e-8f64-483a1a582843",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -117,79 +117,79 @@
       "tag": "guide",
       "documents": [
         {
-          "id": "69c31818-61cb-43a0-88ec-d0920cb706be",
+          "id": "088858bf-a598-412f-b323-cfc19ec47697",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "c772f190-e4f4-46f1-ad03-38bbcef56ace",
+          "id": "ff7f0d34-0fa4-4138-9045-b3a3af093ffb",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "823b55b9-3a1b-443b-8dcd-169378d18852",
+          "id": "b8680798-2aca-4cae-9458-a8e663a4ea85",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "e3476503-a098-4e10-ad65-f39b4c323453",
+          "id": "dd5e2569-c0af-4c23-9c1c-fdc577ac52b2",
           "path": "04-guides/README.json",
           "title": "Guides Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "ac56482d-9528-4bc7-be58-a227b8af050c",
+          "id": "1e1544ff-deab-4978-abd9-51a4b24565df",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "6ef683c1-ee52-447c-b477-0a8c859123d6",
+          "id": "436b2003-522f-43b7-9d42-a69df9e649cf",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "30000933-63e5-4d34-adbe-11ca5f602bad",
+          "id": "1bdf4fc0-e4db-4fe8-9cc1-163af12880d1",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "332b619c-d5bd-41f2-976c-140bfc1ad6f1",
+          "id": "799dc4cc-869b-4447-8475-27fd10fa72a8",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "324d7fd8-a16c-4a6e-baf2-1c9f9cb6df1a",
+          "id": "dcdbb227-4953-46a0-974b-72b90b19e167",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "9ce3a16b-49a6-4475-8479-38772cd99369",
+          "id": "6278869a-e47d-4d75-9468-ea751572eabf",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "3bca0b4b-8467-4fbb-9295-b8a2c61cc9de",
+          "id": "e527abf0-1ea7-4d0f-96c7-0c8b53640e4b",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "31b25b6f-7dee-4b88-a1e6-ba47bdc02689",
+          "id": "d7c30e9d-59d4-463e-8f64-483a1a582843",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -200,13 +200,13 @@
       "tag": "best-practices",
       "documents": [
         {
-          "id": "c8424929-8f5f-4646-b3ae-68dfc06078d6",
+          "id": "790ef101-118e-408e-9d90-7d0c6c2e19ef",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9825e6f4-bd88-49e5-b599-a469ee6a2934",
+          "id": "8ca61516-9132-4625-846a-59d45ff77c39",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -217,13 +217,13 @@
       "tag": "typescript",
       "documents": [
         {
-          "id": "c8424929-8f5f-4646-b3ae-68dfc06078d6",
+          "id": "790ef101-118e-408e-9d90-7d0c6c2e19ef",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9825e6f4-bd88-49e5-b599-a469ee6a2934",
+          "id": "8ca61516-9132-4625-846a-59d45ff77c39",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -234,13 +234,13 @@
       "tag": "clean-code",
       "documents": [
         {
-          "id": "c8424929-8f5f-4646-b3ae-68dfc06078d6",
+          "id": "790ef101-118e-408e-9d90-7d0c6c2e19ef",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9825e6f4-bd88-49e5-b599-a469ee6a2934",
+          "id": "8ca61516-9132-4625-846a-59d45ff77c39",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -251,7 +251,7 @@
       "tag": "overview",
       "documents": [
         {
-          "id": "580d4db5-7011-44e2-a398-00db37c82fc2",
+          "id": "152fb3fc-5f0a-4aee-99b5-97e035e786aa",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -262,49 +262,49 @@
       "tag": "v2",
       "documents": [
         {
-          "id": "580d4db5-7011-44e2-a398-00db37c82fc2",
+          "id": "152fb3fc-5f0a-4aee-99b5-97e035e786aa",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9a955792-83a3-45f8-9181-cd6634c3e07a",
+          "id": "8f51d38d-7a98-4efc-9371-47eed678f1de",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "5227267a-8816-4920-bf0b-dbba86336f48",
+          "id": "a8039911-d922-48ed-8ae6-72ef9c75d774",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "16bb8e47-124b-4958-b388-cd6f234c3f8c",
+          "id": "c24fa3d5-fd35-4262-ac77-3a19f04e1233",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "b420fe50-8f31-4067-87d8-3621c806a691",
+          "id": "f8bbba44-e7b1-4887-a4bd-7c58fdcb9e7f",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "f095c594-27d4-42a0-9ac7-9b05f7d160c8",
+          "id": "584471aa-1eb9-4272-bfed-354a9de2500a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "2462c663-c4b3-43e7-861b-c3aa8d9e3df3",
+          "id": "ac200306-c44c-4cf7-8316-46c87943e08c",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "d07c2fa9-1532-40b2-a016-8925e6687e54",
+          "id": "7d9300f8-2040-47ec-b68f-1f417b3ae2d7",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -315,7 +315,7 @@
       "tag": "tech-stack",
       "documents": [
         {
-          "id": "826150ee-4ffd-4b8c-bdd0-a43b7af1c362",
+          "id": "2ec0b6cc-64d8-4f7e-a2d3-591f1b82e45a",
           "path": "01-project/tech-stack.json",
           "title": "Technology Stack",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -326,13 +326,13 @@
       "tag": "infrastructure",
       "documents": [
         {
-          "id": "826150ee-4ffd-4b8c-bdd0-a43b7af1c362",
+          "id": "2ec0b6cc-64d8-4f7e-a2d3-591f1b82e45a",
           "path": "01-project/tech-stack.json",
           "title": "Technology Stack",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "30000933-63e5-4d34-adbe-11ca5f602bad",
+          "id": "1bdf4fc0-e4db-4fe8-9cc1-163af12880d1",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -343,25 +343,25 @@
       "tag": "architecture",
       "documents": [
         {
-          "id": "c772f190-e4f4-46f1-ad03-38bbcef56ace",
+          "id": "ff7f0d34-0fa4-4138-9045-b3a3af093ffb",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9a955792-83a3-45f8-9181-cd6634c3e07a",
+          "id": "8f51d38d-7a98-4efc-9371-47eed678f1de",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "2462c663-c4b3-43e7-861b-c3aa8d9e3df3",
+          "id": "ac200306-c44c-4cf7-8316-46c87943e08c",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "d65e9155-644f-4271-bb28-5e1da7104ae2",
+          "id": "4d54626d-3c79-4ec0-9429-3c1d1d0d8082",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -372,31 +372,31 @@
       "tag": "design",
       "documents": [
         {
-          "id": "c772f190-e4f4-46f1-ad03-38bbcef56ace",
+          "id": "ff7f0d34-0fa4-4138-9045-b3a3af093ffb",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "9a955792-83a3-45f8-9181-cd6634c3e07a",
+          "id": "8f51d38d-7a98-4efc-9371-47eed678f1de",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "5227267a-8816-4920-bf0b-dbba86336f48",
+          "id": "a8039911-d922-48ed-8ae6-72ef9c75d774",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "2462c663-c4b3-43e7-861b-c3aa8d9e3df3",
+          "id": "ac200306-c44c-4cf7-8316-46c87943e08c",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "eaac1ceb-8564-4e5a-91e5-0b8cae8aacfb",
+          "id": "a5a5f52c-37c3-4529-9c4b-8974be58e21d",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -407,13 +407,13 @@
       "tag": "decision",
       "documents": [
         {
-          "id": "9a955792-83a3-45f8-9181-cd6634c3e07a",
+          "id": "8f51d38d-7a98-4efc-9371-47eed678f1de",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "2462c663-c4b3-43e7-861b-c3aa8d9e3df3",
+          "id": "ac200306-c44c-4cf7-8316-46c87943e08c",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -424,13 +424,13 @@
       "tag": "json",
       "documents": [
         {
-          "id": "9a955792-83a3-45f8-9181-cd6634c3e07a",
+          "id": "8f51d38d-7a98-4efc-9371-47eed678f1de",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "d07c2fa9-1532-40b2-a016-8925e6687e54",
+          "id": "7d9300f8-2040-47ec-b68f-1f417b3ae2d7",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -441,13 +441,13 @@
       "tag": "analysis",
       "documents": [
         {
-          "id": "4f8ec43c-84ba-43de-a7a0-9163d979f747",
+          "id": "8f834c91-8a56-48fc-95c9-6d8a05e5e952",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -458,37 +458,37 @@
       "tag": "memory-bank",
       "documents": [
         {
-          "id": "4f8ec43c-84ba-43de-a7a0-9163d979f747",
+          "id": "8f834c91-8a56-48fc-95c9-6d8a05e5e952",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "27c4daa1-dbea-4c22-bd32-53ed022a1e18",
+          "id": "cfe97743-dc85-4c50-9a86-ab532dbac8b4",
           "path": "07-infrastructure/ci-cd/memory-bank-errors.json",
           "title": "Memory Bank Error Troubleshooting",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "eaac1ceb-8564-4e5a-91e5-0b8cae8aacfb",
+          "id": "a5a5f52c-37c3-4529-9c4b-8974be58e21d",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "79f1560e-1817-4ce0-90f3-41902294844a",
+          "id": "0e2cefc5-69cd-4611-af3e-76736ec4b099",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3a22e489-001c-435f-a74f-e97da709a2f6",
+          "id": "0145069f-ecb3-46b8-8209-dad3da1937dc",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -499,7 +499,7 @@
       "tag": "organization",
       "documents": [
         {
-          "id": "4f8ec43c-84ba-43de-a7a0-9163d979f747",
+          "id": "8f834c91-8a56-48fc-95c9-6d8a05e5e952",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -510,49 +510,49 @@
       "tag": "meta",
       "documents": [
         {
-          "id": "4f8ec43c-84ba-43de-a7a0-9163d979f747",
+          "id": "8f834c91-8a56-48fc-95c9-6d8a05e5e952",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3bca0b4b-8467-4fbb-9295-b8a2c61cc9de",
+          "id": "e527abf0-1ea7-4d0f-96c7-0c8b53640e4b",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "a57a7f72-c0e9-48b4-b4af-d495ba786773",
+          "id": "8b496b73-eb96-4d70-8fbe-a263fce4c3d8",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "31b25b6f-7dee-4b88-a1e6-ba47bdc02689",
+          "id": "d7c30e9d-59d4-463e-8f64-483a1a582843",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "5f1b9ba8-0f65-441a-99db-648ba5368af4",
+          "id": "d0a30451-234a-455e-806b-085704f6bace",
           "path": "tags/index.json",
           "title": "タグインデックス",
-          "lastModified": "2025-04-06T13:28:28.028Z"
+          "lastModified": "2025-04-08T04:44:04.926Z"
         },
         {
-          "id": "79f1560e-1817-4ce0-90f3-41902294844a",
+          "id": "0e2cefc5-69cd-4611-af3e-76736ec4b099",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3a22e489-001c-435f-a74f-e97da709a2f6",
+          "id": "0145069f-ecb3-46b8-8209-dad3da1937dc",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -563,25 +563,25 @@
       "tag": "implementation",
       "documents": [
         {
-          "id": "823b55b9-3a1b-443b-8dcd-169378d18852",
+          "id": "b8680798-2aca-4cae-9458-a8e663a4ea85",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "16bb8e47-124b-4958-b388-cd6f234c3f8c",
+          "id": "c24fa3d5-fd35-4262-ac77-3a19f04e1233",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "b420fe50-8f31-4067-87d8-3621c806a691",
+          "id": "f8bbba44-e7b1-4887-a4bd-7c58fdcb9e7f",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "d07c2fa9-1532-40b2-a016-8925e6687e54",
+          "id": "7d9300f8-2040-47ec-b68f-1f417b3ae2d7",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -592,19 +592,19 @@
       "tag": "mcp",
       "documents": [
         {
-          "id": "5227267a-8816-4920-bf0b-dbba86336f48",
+          "id": "a8039911-d922-48ed-8ae6-72ef9c75d774",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "16bb8e47-124b-4958-b388-cd6f234c3f8c",
+          "id": "c24fa3d5-fd35-4262-ac77-3a19f04e1233",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "9ce3a16b-49a6-4475-8479-38772cd99369",
+          "id": "6278869a-e47d-4d75-9468-ea751572eabf",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -615,13 +615,13 @@
       "tag": "command",
       "documents": [
         {
-          "id": "5227267a-8816-4920-bf0b-dbba86336f48",
+          "id": "a8039911-d922-48ed-8ae6-72ef9c75d774",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "16bb8e47-124b-4958-b388-cd6f234c3f8c",
+          "id": "c24fa3d5-fd35-4262-ac77-3a19f04e1233",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -632,13 +632,13 @@
       "tag": "context",
       "documents": [
         {
-          "id": "5227267a-8816-4920-bf0b-dbba86336f48",
+          "id": "a8039911-d922-48ed-8ae6-72ef9c75d774",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "16bb8e47-124b-4958-b388-cd6f234c3f8c",
+          "id": "c24fa3d5-fd35-4262-ac77-3a19f04e1233",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -649,13 +649,13 @@
       "tag": "testing",
       "documents": [
         {
-          "id": "ac56482d-9528-4bc7-be58-a227b8af050c",
+          "id": "1e1544ff-deab-4978-abd9-51a4b24565df",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "edddefdf-f3cb-44b3-a69d-db7dacd2e68f",
+          "id": "4270073c-920d-4365-aec3-b42edec00127",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -666,7 +666,7 @@
       "tag": "e2e",
       "documents": [
         {
-          "id": "edddefdf-f3cb-44b3-a69d-db7dacd2e68f",
+          "id": "4270073c-920d-4365-aec3-b42edec00127",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -677,13 +677,13 @@
       "tag": "integration-test",
       "documents": [
         {
-          "id": "edddefdf-f3cb-44b3-a69d-db7dacd2e68f",
+          "id": "4270073c-920d-4365-aec3-b42edec00127",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "eaac1ceb-8564-4e5a-91e5-0b8cae8aacfb",
+          "id": "a5a5f52c-37c3-4529-9c4b-8974be58e21d",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -694,7 +694,7 @@
       "tag": "tdd",
       "documents": [
         {
-          "id": "edddefdf-f3cb-44b3-a69d-db7dacd2e68f",
+          "id": "4270073c-920d-4365-aec3-b42edec00127",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -705,7 +705,7 @@
       "tag": "qa",
       "documents": [
         {
-          "id": "edddefdf-f3cb-44b3-a69d-db7dacd2e68f",
+          "id": "4270073c-920d-4365-aec3-b42edec00127",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -716,31 +716,31 @@
       "tag": "release",
       "documents": [
         {
-          "id": "6ef683c1-ee52-447c-b477-0a8c859123d6",
+          "id": "436b2003-522f-43b7-9d42-a69df9e649cf",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "b420fe50-8f31-4067-87d8-3621c806a691",
+          "id": "f8bbba44-e7b1-4887-a4bd-7c58fdcb9e7f",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "f095c594-27d4-42a0-9ac7-9b05f7d160c8",
+          "id": "584471aa-1eb9-4272-bfed-354a9de2500a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "cd6f2590-c557-42e6-b9af-f030729ce711",
+          "id": "c542e453-6645-4636-8df8-2edb0cd963f1",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "b56be8d4-277e-44f9-bf72-7ca567d6e841",
+          "id": "fc4a6431-be9e-4e97-b6a8-baeca3f45283",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -751,7 +751,7 @@
       "tag": "version",
       "documents": [
         {
-          "id": "6ef683c1-ee52-447c-b477-0a8c859123d6",
+          "id": "436b2003-522f-43b7-9d42-a69df9e649cf",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -762,13 +762,13 @@
       "tag": "planning",
       "documents": [
         {
-          "id": "b420fe50-8f31-4067-87d8-3621c806a691",
+          "id": "f8bbba44-e7b1-4887-a4bd-7c58fdcb9e7f",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "b56be8d4-277e-44f9-bf72-7ca567d6e841",
+          "id": "fc4a6431-be9e-4e97-b6a8-baeca3f45283",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -779,13 +779,13 @@
       "tag": "changelog",
       "documents": [
         {
-          "id": "b420fe50-8f31-4067-87d8-3621c806a691",
+          "id": "f8bbba44-e7b1-4887-a4bd-7c58fdcb9e7f",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "f095c594-27d4-42a0-9ac7-9b05f7d160c8",
+          "id": "584471aa-1eb9-4272-bfed-354a9de2500a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -796,7 +796,7 @@
       "tag": "pr",
       "documents": [
         {
-          "id": "f095c594-27d4-42a0-9ac7-9b05f7d160c8",
+          "id": "584471aa-1eb9-4272-bfed-354a9de2500a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -807,7 +807,7 @@
       "tag": "v2-2-0",
       "documents": [
         {
-          "id": "cd6f2590-c557-42e6-b9af-f030729ce711",
+          "id": "c542e453-6645-4636-8df8-2edb0cd963f1",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -818,7 +818,7 @@
       "tag": "json-patch",
       "documents": [
         {
-          "id": "cd6f2590-c557-42e6-b9af-f030729ce711",
+          "id": "c542e453-6645-4636-8df8-2edb0cd963f1",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -829,13 +829,13 @@
       "tag": "plan",
       "documents": [
         {
-          "id": "d07c2fa9-1532-40b2-a016-8925e6687e54",
+          "id": "7d9300f8-2040-47ec-b68f-1f417b3ae2d7",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "3a22e489-001c-435f-a74f-e97da709a2f6",
+          "id": "0145069f-ecb3-46b8-8209-dad3da1937dc",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -846,7 +846,7 @@
       "tag": "v2-1-0",
       "documents": [
         {
-          "id": "b56be8d4-277e-44f9-bf72-7ca567d6e841",
+          "id": "fc4a6431-be9e-4e97-b6a8-baeca3f45283",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -857,7 +857,7 @@
       "tag": "json-migration",
       "documents": [
         {
-          "id": "b56be8d4-277e-44f9-bf72-7ca567d6e841",
+          "id": "fc4a6431-be9e-4e97-b6a8-baeca3f45283",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -868,7 +868,7 @@
       "tag": "operations",
       "documents": [
         {
-          "id": "30000933-63e5-4d34-adbe-11ca5f602bad",
+          "id": "1bdf4fc0-e4db-4fe8-9cc1-163af12880d1",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -879,7 +879,7 @@
       "tag": "troubleshooting",
       "documents": [
         {
-          "id": "27c4daa1-dbea-4c22-bd32-53ed022a1e18",
+          "id": "cfe97743-dc85-4c50-9a86-ab532dbac8b4",
           "path": "07-infrastructure/ci-cd/memory-bank-errors.json",
           "title": "Memory Bank Error Troubleshooting",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -890,7 +890,7 @@
       "tag": "ci-cd",
       "documents": [
         {
-          "id": "d4cb54ce-3d23-4513-a9cc-c772cfa69eec",
+          "id": "7bcba4ba-86b8-40c1-beef-97273bde3aca",
           "path": "07-infrastructure/ci-cd/workflows.json",
           "title": "CI/CD Workflows",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -901,7 +901,7 @@
       "tag": "i18n",
       "documents": [
         {
-          "id": "332b619c-d5bd-41f2-976c-140bfc1ad6f1",
+          "id": "799dc4cc-869b-4447-8475-27fd10fa72a8",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -912,7 +912,7 @@
       "tag": "l10n",
       "documents": [
         {
-          "id": "332b619c-d5bd-41f2-976c-140bfc1ad6f1",
+          "id": "799dc4cc-869b-4447-8475-27fd10fa72a8",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -923,13 +923,13 @@
       "tag": "refactoring",
       "documents": [
         {
-          "id": "324d7fd8-a16c-4a6e-baf2-1c9f9cb6df1a",
+          "id": "dcdbb227-4953-46a0-974b-72b90b19e167",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "eaac1ceb-8564-4e5a-91e5-0b8cae8aacfb",
+          "id": "a5a5f52c-37c3-4529-9c4b-8974be58e21d",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -940,13 +940,13 @@
       "tag": "tech-debt",
       "documents": [
         {
-          "id": "324d7fd8-a16c-4a6e-baf2-1c9f9cb6df1a",
+          "id": "dcdbb227-4953-46a0-974b-72b90b19e167",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "eaac1ceb-8564-4e5a-91e5-0b8cae8aacfb",
+          "id": "a5a5f52c-37c3-4529-9c4b-8974be58e21d",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -957,7 +957,7 @@
       "tag": "system-design",
       "documents": [
         {
-          "id": "d65e9155-644f-4271-bb28-5e1da7104ae2",
+          "id": "4d54626d-3c79-4ec0-9429-3c1d1d0d8082",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -968,25 +968,25 @@
       "tag": "core",
       "documents": [
         {
-          "id": "d65e9155-644f-4271-bb28-5e1da7104ae2",
+          "id": "4d54626d-3c79-4ec0-9429-3c1d1d0d8082",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9825e6f4-bd88-49e5-b599-a469ee6a2934",
+          "id": "8ca61516-9132-4625-846a-59d45ff77c39",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "53fc0d4d-c7fd-4bba-9461-de76d5fe20fd",
+          "id": "8e9e22ae-14ee-41b5-8fef-4a58809e9557",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9ce3a16b-49a6-4475-8479-38772cd99369",
+          "id": "6278869a-e47d-4d75-9468-ea751572eabf",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -997,13 +997,13 @@
       "tag": "standards",
       "documents": [
         {
-          "id": "9825e6f4-bd88-49e5-b599-a469ee6a2934",
+          "id": "8ca61516-9132-4625-846a-59d45ff77c39",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "a57a7f72-c0e9-48b4-b4af-d495ba786773",
+          "id": "8b496b73-eb96-4d70-8fbe-a263fce4c3d8",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1014,7 +1014,7 @@
       "tag": "glossary",
       "documents": [
         {
-          "id": "53fc0d4d-c7fd-4bba-9461-de76d5fe20fd",
+          "id": "8e9e22ae-14ee-41b5-8fef-4a58809e9557",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1025,7 +1025,7 @@
       "tag": "terminology",
       "documents": [
         {
-          "id": "53fc0d4d-c7fd-4bba-9461-de76d5fe20fd",
+          "id": "8e9e22ae-14ee-41b5-8fef-4a58809e9557",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1036,7 +1036,7 @@
       "tag": "definitions",
       "documents": [
         {
-          "id": "53fc0d4d-c7fd-4bba-9461-de76d5fe20fd",
+          "id": "8e9e22ae-14ee-41b5-8fef-4a58809e9557",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1047,7 +1047,7 @@
       "tag": "manual",
       "documents": [
         {
-          "id": "9ce3a16b-49a6-4475-8479-38772cd99369",
+          "id": "6278869a-e47d-4d75-9468-ea751572eabf",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1058,7 +1058,7 @@
       "tag": "en",
       "documents": [
         {
-          "id": "9ce3a16b-49a6-4475-8479-38772cd99369",
+          "id": "6278869a-e47d-4d75-9468-ea751572eabf",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1069,7 +1069,7 @@
       "tag": "navigation",
       "documents": [
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1080,19 +1080,19 @@
       "tag": "reference",
       "documents": [
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "a57a7f72-c0e9-48b4-b4af-d495ba786773",
+          "id": "8b496b73-eb96-4d70-8fbe-a263fce4c3d8",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "79f1560e-1817-4ce0-90f3-41902294844a",
+          "id": "0e2cefc5-69cd-4611-af3e-76736ec4b099",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -1103,31 +1103,31 @@
       "tag": "index",
       "documents": [
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "31b25b6f-7dee-4b88-a1e6-ba47bdc02689",
+          "id": "d7c30e9d-59d4-463e-8f64-483a1a582843",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "5f1b9ba8-0f65-441a-99db-648ba5368af4",
+          "id": "d0a30451-234a-455e-806b-085704f6bace",
           "path": "tags/index.json",
           "title": "タグインデックス",
-          "lastModified": "2025-04-06T13:28:28.028Z"
+          "lastModified": "2025-04-08T04:44:04.926Z"
         },
         {
-          "id": "79f1560e-1817-4ce0-90f3-41902294844a",
+          "id": "0e2cefc5-69cd-4611-af3e-76736ec4b099",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3a22e489-001c-435f-a74f-e97da709a2f6",
+          "id": "0145069f-ecb3-46b8-8209-dad3da1937dc",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -1138,25 +1138,25 @@
       "tag": "tag",
       "documents": [
         {
-          "id": "56d855da-cfce-47fe-b9c0-b3dd6123daec",
+          "id": "2be1217e-8a40-4a5f-affb-9df46fcf1caa",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "31b25b6f-7dee-4b88-a1e6-ba47bdc02689",
+          "id": "d7c30e9d-59d4-463e-8f64-483a1a582843",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "79f1560e-1817-4ce0-90f3-41902294844a",
+          "id": "0e2cefc5-69cd-4611-af3e-76736ec4b099",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3a22e489-001c-435f-a74f-e97da709a2f6",
+          "id": "0145069f-ecb3-46b8-8209-dad3da1937dc",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"

--- a/packages/mcp/src/application/dtos/DocumentDTO.ts
+++ b/packages/mcp/src/application/dtos/DocumentDTO.ts
@@ -10,7 +10,7 @@ export interface DocumentDTO {
   /**
    * Document content
    */
-  content: string;
+  content: string | object;
 
   /**
    * Document tags

--- a/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/branch/ReadBranchDocumentUseCase.ts
@@ -136,11 +136,21 @@ export class ReadBranchDocumentUseCase
       documentType: (document as any).determineDocumentType()
     });
 
-    // MemoryDocument から生の content 文字列を取得する
+    // Attempt to parse the content as JSON
+    let parsedContent: string | object;
+    try {
+      parsedContent = JSON.parse(document.content);
+      this.useCaseLogger.debug('Successfully parsed document content as JSON', { documentPath: input.path });
+    } catch (parseError) {
+      // If parsing fails, keep the original string content
+      parsedContent = document.content;
+      this.useCaseLogger.debug('Failed to parse document content as JSON, returning as string', { documentPath: input.path });
+    }
+
     return {
       document: {
         path: document.path.value,
-        content: document.content, // ★ 生の content 文字列をそのまま返す ★
+        content: parsedContent, // Return parsed object or original string
         tags: document.tags.map((tag) => tag.value),
         lastModified: document.lastModified.toISOString(),
       },

--- a/packages/mcp/src/application/usecases/common/ReadRulesUseCase.ts
+++ b/packages/mcp/src/application/usecases/common/ReadRulesUseCase.ts
@@ -7,7 +7,7 @@ import { TemplateService } from '../../templates/TemplateService.js'; // Import 
 import { Language } from '../../../domain/i18n/Language.js'; // Import Language class from domain
 import { getSafeLanguage } from '@memory-bank/schemas'; // Use package name import
 export type RulesResult = {
-  content: string;
+  content: Record<string, unknown>; // Change type to object
   language: string;
 };
 
@@ -73,10 +73,9 @@ constructor(
             langObject // Pass Language object
           );
 
-          const content = JSON.stringify(templateJsonObject, null, 2);
-
+          // Return the object directly
           return {
-            content: content,
+            content: templateJsonObject, // Return the object
             language
           };
         } catch (templateError) {

--- a/packages/mcp/src/application/usecases/global/ReadGlobalDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/global/ReadGlobalDocumentUseCase.ts
@@ -63,11 +63,16 @@ export class ReadGlobalDocumentUseCase
       }
 
       let parsedContent: string | object;
-      try {
-        // Attempt to parse the content as JSON
-        parsedContent = JSON.parse(document.content);
-      } catch (parseError) {
-        // If parsing fails, keep the original string content
+      if (typeof document.content === 'string') {
+        try {
+          // Attempt to parse the content as JSON
+          parsedContent = JSON.parse(document.content);
+        } catch (parseError) {
+          // If parsing fails, keep the original string content
+          parsedContent = document.content;
+        }
+      } else {
+        // If content is already an object, use it directly
         parsedContent = document.content;
       }
 

--- a/packages/mcp/src/application/usecases/global/ReadGlobalDocumentUseCase.ts
+++ b/packages/mcp/src/application/usecases/global/ReadGlobalDocumentUseCase.ts
@@ -62,10 +62,19 @@ export class ReadGlobalDocumentUseCase
         );
       }
 
+      let parsedContent: string | object;
+      try {
+        // Attempt to parse the content as JSON
+        parsedContent = JSON.parse(document.content);
+      } catch (parseError) {
+        // If parsing fails, keep the original string content
+        parsedContent = document.content;
+      }
+
       return {
         document: {
           path: document.path.value,
-          content: document.content,
+          content: parsedContent, // Return parsed object or original string
           tags: document.tags.map((tag) => tag.value),
           lastModified: document.lastModified.toISOString(),
         },

--- a/packages/mcp/src/application/usecases/types.ts
+++ b/packages/mcp/src/application/usecases/types.ts
@@ -2,7 +2,7 @@
  * Rules result type
  */
 export type RulesResult = {
-  content: string;
+  content: Record<string, unknown>; // Allow object
   language: string;
 };
 
@@ -19,6 +19,6 @@ export type ContextRequest = {
  */
 export type ContextResult = {
   rules?: RulesResult;
-  branchMemory?: Record<string, string>;
-  globalMemory?: Record<string, string>;
+  branchMemory?: Record<string, string | object>; // Allow object
+  globalMemory?: Record<string, string | object>; // Allow object
 };

--- a/packages/mcp/src/interface/controllers/GlobalController.ts
+++ b/packages/mcp/src/interface/controllers/GlobalController.ts
@@ -20,7 +20,7 @@ import type { IConfigProvider } from "../../infrastructure/config/interfaces/ICo
  */
 interface WriteGlobalDocumentParams {
   path: string;
-  content?: string;
+  content?: string | Record<string, unknown>; // Allow object
   patches?: rfc6902.Operation[];
   tags?: string[];
 }

--- a/packages/mcp/tests/e2e/branch-memory-bank.e2e.test.ts
+++ b/packages/mcp/tests/e2e/branch-memory-bank.e2e.test.ts
@@ -60,7 +60,9 @@ describe('MCP E2E Branch Memory Bank Tests', () => {
       const document = (readResult.data as any).document as DocumentDTO;
       expect(document.path).toBe(testDocPath);
       expect(document.tags).toEqual(expect.arrayContaining(['initial', 'write-test']));
-      const parsedContent = JSON.parse(document.content);
+      // document.content should already be an object
+      expect(typeof document.content).toBe('object');
+      const parsedContent = document.content as any; // Assert type
       expect(parsedContent.content.message).toBe('Initial content');
     } else {
       fail('readDocument should return success: true');
@@ -102,7 +104,9 @@ describe('MCP E2E Branch Memory Bank Tests', () => {
 
       const document = (readResult.data as any).document as DocumentDTO;
       expect(document.tags).toEqual(expect.arrayContaining(['patch-test', 'patched']));
-      const parsedContent = JSON.parse(document.content);
+      // document.content should already be an object
+      expect(typeof document.content).toBe('object');
+      const parsedContent = document.content as any; // Assert type
       expect(parsedContent.content.newField).toBe(true);
     } else {
       fail('readDocument should return success: true');

--- a/packages/mcp/tests/e2e/context.e2e.test.ts
+++ b/packages/mcp/tests/e2e/context.e2e.test.ts
@@ -64,18 +64,16 @@ describe('MCP E2E Context Tests', () => {
       expect(data.branchMemory).toBeDefined();
       expect(typeof data.branchMemory).toBe('object');
       expect(data.branchMemory?.[branchDocPath]).toBeDefined();
-      const branchDocContentString = data.branchMemory?.[branchDocPath];
-      expect(typeof branchDocContentString).toBe('string');
-      const parsedBranchContent = JSON.parse(branchDocContentString ?? '{}');
-      expect(parsedBranchContent.metadata.id).toBe("context-branch-1");
+      const parsedBranchContent = data.branchMemory?.[branchDocPath]; // Content is already an object
+      expect(typeof parsedBranchContent).toBe('object'); // Verify it's an object
+      expect((parsedBranchContent as any)?.metadata?.id).toBe("context-branch-1"); // Add optional chaining and type assertion
 
       expect(data.globalMemory).toBeDefined();
       expect(typeof data.globalMemory).toBe('object');
       expect(data.globalMemory?.[globalDocPath]).toBeDefined();
-      const globalDocContentString = data.globalMemory?.[globalDocPath];
-      expect(typeof globalDocContentString).toBe('string');
-      const parsedGlobalContent = JSON.parse(globalDocContentString ?? '{}');
-      expect(parsedGlobalContent.metadata.id).toBe("context-global-1");
+      const parsedGlobalContent = data.globalMemory?.[globalDocPath]; // Content is already an object
+      expect(typeof parsedGlobalContent).toBe('object'); // Verify it's an object
+      expect((parsedGlobalContent as any)?.metadata?.id).toBe("context-global-1"); // Add optional chaining and type assertion
     } else {
       fail('readContext should return success: true with data');
     }

--- a/packages/mcp/tests/e2e/global-memory-bank.e2e.test.ts
+++ b/packages/mcp/tests/e2e/global-memory-bank.e2e.test.ts
@@ -51,7 +51,9 @@ describe('MCP E2E Global Memory Bank Tests', () => {
       expect(document.path).toBe(testDocPath);
       // TODO: tags プロパティ確認 (DocumentDTO に tags が追加されたらコメント解除)
       // expect(document.tags).toEqual(expect.arrayContaining(["global", "initial", "write-test"]));
-      const parsedContent = JSON.parse(document.content);
+      // document.content should already be an object
+      expect(typeof document.content).toBe('object');
+      const parsedContent = document.content as any; // Assert type
       expect(parsedContent.content.message).toBe("Initial global content");
     } else {
       fail('readDocument should return success: true');

--- a/packages/mcp/tests/e2e/initialization.e2e.test.ts
+++ b/packages/mcp/tests/e2e/initialization.e2e.test.ts
@@ -66,9 +66,9 @@ describe('MCP E2E Initialization Tests', () => {
       const document = (readResult.data as any).document as DocumentDTO;
 
       expect(document.content).toBeDefined();
-      expect(typeof document.content).toBe('string');
+      expect(typeof document.content).toBe('object'); // Expect object
 
-      const parsedContent = JSON.parse(document.content);
+      const parsedContent = document.content as any; // Content is already an object
       expect(parsedContent.metadata.id).toBe('test-e2e-init-doc');
       expect(parsedContent.content.value).toBe('Document content for E2E initialization test'); // Match the actual written content
       expect(document.tags).toEqual(expect.arrayContaining(["test", "e2e", "init"]));

--- a/packages/mcp/tests/integration/controller/BranchController.integration.test.ts
+++ b/packages/mcp/tests/integration/controller/BranchController.integration.test.ts
@@ -95,12 +95,12 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.success).toBe(true);
       if (!readResult.success) throw new Error('Expected success but got error'); // Use throw new Error
       expect(readResult.data).toBeDefined();
-      // readResult.data の型ガードも追加 (readDocument は DocumentDTO を返す想定)
-      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' });
-          throw new Error('Expected readResult.data.document.content to be a string');
+      // Check if content is an object (since ReadUseCase now parses JSON)
+      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'object') {
+          logger.error("--- Assertion Error: readResult.data.document.content was not an object.", { actualData: readResult.data, component: 'BranchController.integration.test' });
+          throw new Error('Expected readResult.data.document.content to be an object');
       }
-      const parsed = JSON.parse(readResult.data.document.content);
+      const parsed = readResult.data.document.content as any; // Content is already an object
 
       // Use testDoc for comparison as it has the correct path
       expect(parsed.metadata.id).toBe(testDoc.metadata.id);
@@ -165,12 +165,12 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.success).toBe(true);
       if (!readResult.success) throw new Error('Expected success but got error'); // Use throw new Error
       expect(readResult.data).toBeDefined();
-      // readResult.data の型ガードも追加
-      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' });
-          throw new Error('Expected readResult.data.document.content to be a string');
+      // Check if content is an object
+      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'object') {
+          logger.error("--- Assertion Error: readResult.data.document.content was not an object.", { actualData: readResult.data, component: 'BranchController.integration.test' });
+          throw new Error('Expected readResult.data.document.content to be an object');
       }
-      const parsed = JSON.parse(readResult.data.document.content);
+      const parsed = readResult.data.document.content as any; // Content is already an object
       // Use newBranchDoc for comparison
       expect(parsed.metadata.id).toBe(newBranchDoc.metadata.id);
       expect(parsed.content.value).toBe(newBranchDoc.content.value);
@@ -233,12 +233,12 @@ describe('BranchController Integration Tests', () => {
       expect(readResult.success).toBe(true);
       if (!readResult.success) throw new Error('Expected success but got error on read after update'); // Use throw new Error
       expect(readResult.data).toBeDefined();
-      // readResult.data の型ガードも追加
-      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'string') {
-          logger.error("--- Assertion Error: readResult.data.document.content was not a string.", { actualData: readResult.data, component: 'BranchController.integration.test' });
-          throw new Error('Expected readResult.data.document.content to be a string');
+      // Check if content is an object
+      if (!readResult.data || !readResult.data.document || typeof readResult.data.document.content !== 'object') {
+          logger.error("--- Assertion Error: readResult.data.document.content was not an object.", { actualData: readResult.data, component: 'BranchController.integration.test' });
+          throw new Error('Expected readResult.data.document.content to be an object');
       }
-      const parsed = JSON.parse(readResult.data.document.content);
+      const parsed = readResult.data.document.content as any; // Content is already an object
 
       expect(parsed.metadata.id).toBe(updatedDoc.metadata.id);
       expect(parsed.metadata.title).toBe(updatedDoc.metadata.title);

--- a/packages/mcp/tests/integration/controller/ContextController.integration.test.ts
+++ b/packages/mcp/tests/integration/controller/ContextController.integration.test.ts
@@ -99,14 +99,15 @@ describe('ContextController Integration Tests', () => {
       expect(result.data?.branchMemory?.['activeContext.json']).toBeDefined();
       expect(result.data?.branchMemory?.['branchContext.json']).toBeDefined();
 
-      const branchContextContent = result.data?.branchMemory?.['branchContext.json'];
-      expect(branchContextContent).toBeDefined();
-      const branchContext = JSON.parse(branchContextContent!);
+      const branchContext = result.data?.branchMemory?.['branchContext.json']; // Content is already an object
+      expect(branchContext).toBeDefined();
+      expect(typeof branchContext).toBe('object'); // Verify it's an object
+      // Assert properties on the object directly
       expect(branchContext).toHaveProperty('schema');
-      expect(branchContext).toHaveProperty('documentType'); // documentType がトップレベルにあることを確認
+      expect(branchContext).toHaveProperty('documentType');
       expect(branchContext).toHaveProperty('metadata');
       expect(branchContext).toHaveProperty('content');
-      expect(branchContext.documentType).toBe('branch_context'); // トップレベルの documentType をチェック
+      expect((branchContext as any).documentType).toBe('branch_context'); // Assert type for property access
     });
   });
   describe('readRules', () => {
@@ -118,7 +119,8 @@ describe('ContextController Integration Tests', () => {
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('ja');
       expect(result.data!.content).toBeDefined();
-      expect(result.data!.content.length).toBeGreaterThan(0);
+      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
+      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
       expect(result.error).toBeUndefined();
     });
 
@@ -131,7 +133,8 @@ describe('ContextController Integration Tests', () => {
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('en');
       expect(result.data!.content).toBeDefined();
-      expect(result.data!.content.length).toBeGreaterThan(0);
+      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
+      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
       expect(result.error).toBeUndefined();
     });
 
@@ -155,7 +158,8 @@ describe('ContextController Integration Tests', () => {
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('zh');
       expect(result.data!.content).toBeDefined();
-      expect(result.data!.content.length).toBeGreaterThan(0);
+      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
+      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
       expect(result.error).toBeUndefined();
     });
   });

--- a/packages/mcp/tests/integration/controller/GlobalController.integration.test.ts
+++ b/packages/mcp/tests/integration/controller/GlobalController.integration.test.ts
@@ -56,9 +56,9 @@ describe('GlobalController Integration Tests', () => {
       if (!result.success) fail('Expected success but got error'); // Add type guard
       expect(result.data).toBeDefined();
       expect(result.data.path).toBe('core/glossary.json');
-      expect(typeof result.data.content).toBe('string');
+      expect(typeof result.data.content).toBe('object'); // Expect object
 
-      const parsed = JSON.parse(result.data.content);
+      const parsed = result.data.content as any; // Content is already an object
       expect(parsed).toHaveProperty('schema');
       expect(parsed).toHaveProperty('metadata');
       expect(parsed).toHaveProperty('content');
@@ -97,11 +97,12 @@ describe('GlobalController Integration Tests', () => {
           value: "簡単なテストドキュメント"
         }
       };
-      const documentContentString = JSON.stringify(testDoc, null, 2);
+      // Pass the object directly to test formatting on write
+      // const documentContentString = JSON.stringify(testDoc, null, 2);
 
       const writeResult = await controller.writeDocument({
         path: documentPath,
-        content: documentContentString
+        content: testDoc // Pass the object directly
       });
 
       expect(writeResult.success).toBe(true);
@@ -112,7 +113,8 @@ describe('GlobalController Integration Tests', () => {
       expect(readResult.success).toBe(true);
       if (!readResult.success) fail('Expected success but got error on read'); // Add type guard
       expect(readResult.data).toBeDefined();
-      const parsedRead = JSON.parse(readResult.data.content);
+      // readResult.data.content is already an object
+      const parsedRead = readResult.data.content as any;
       // Use testDoc for comparison
       expect(parsedRead.metadata.id).toBe(testDoc.metadata.id);
       expect(parsedRead.content.value).toBe(testDoc.content.value);
@@ -180,16 +182,17 @@ describe('GlobalController Integration Tests', () => {
         metadata: { ...simpleDocument.metadata, id: "update-test-updated", title: "Updated Global Title", path: documentPath, version: 2 }, // metadata から documentType 削除
         content: { value: "Updated global content" }
       };
-      const updatedContentString = JSON.stringify(updatedDoc, null, 2);
+      // Pass objects directly
+      // const updatedContentString = JSON.stringify(updatedDoc, null, 2);
 
-      // 1. Write initial document
-      const initialWriteResult = await controller.writeDocument({ path: documentPath, content: initialContentString });
+      // 1. Write initial document (pass object)
+      const initialWriteResult = await controller.writeDocument({ path: documentPath, content: initialDoc });
       expect(initialWriteResult.success).toBe(true);
       if (!initialWriteResult.success) fail('Expected success but got error on initial write');
       expect(initialWriteResult.data).toBeDefined();
 
-      // 2. Write updated document (overwrite)
-      const updateResult = await controller.writeDocument({ path: documentPath, content: updatedContentString });
+      // 2. Write updated document (overwrite, pass object)
+      const updateResult = await controller.writeDocument({ path: documentPath, content: updatedDoc });
       expect(updateResult.success).toBe(true);
       if (!updateResult.success) fail('Expected success but got error on update write');
       expect(updateResult.data).toBeDefined(); // Remove message check
@@ -199,7 +202,8 @@ describe('GlobalController Integration Tests', () => {
       expect(readResult.success).toBe(true);
       if (!readResult.success) fail('Expected success but got error on read after update');
       expect(readResult.data).toBeDefined();
-      const parsed = JSON.parse(readResult.data.content);
+      // readResult.data.content is already an object
+      const parsed = readResult.data.content as any;
 
       expect(parsed.metadata.id).toBe(updatedDoc.metadata.id);
       expect(parsed.metadata.title).toBe(updatedDoc.metadata.title);

--- a/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadBranchDocumentUseCase.integration.test.ts
@@ -110,11 +110,11 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
       expect(result).toBeDefined();
       expect(result.document).toBeDefined();
       expect(result.document.path).toBe('branchContext.json');
-      expect(typeof result.document.content).toBe('string');
+      expect(typeof result.document.content).toBe('object'); // Expect object
 
-      // console.log を復活させて、パース直前の文字列を確認！
-      console.log('### Raw content before parse:', result.document.content);
-      const document = JSON.parse(result.document.content);
+      // console.log は不要になったので削除
+      // console.log('### Raw content before parse:', result.document.content);
+      const document = result.document.content as any; // Use content directly and assert type
       // console.log('### Parsed document:', JSON.stringify(document, null, 2)); // パース後のログは一旦不要
       expect(document).toHaveProperty('schema', 'memory_document_v2');
       // Check if documentType exists at the top level after parsing
@@ -208,9 +208,9 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
       expect(result).toBeDefined();
       expect(result.document).toBeDefined();
       expect(result.document.path).toBe('subdir/test-document.json');
-      expect(typeof result.document.content).toBe('string');
+      expect(typeof result.document.content).toBe('object'); // Expect object
 
-      const document = JSON.parse(result.document.content);
+      const document = result.document.content as any; // Use content directly and assert type
       // このテストケースの期待値はこれで合ってるはず
       expect(document.metadata.id).toBe('subdirectory-document');
       expect(document.metadata.path).toBe('subdir/test-document.json');
@@ -242,7 +242,8 @@ describe('ReadBranchDocumentUseCase Integration Tests', () => {
         expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1); // GitService が呼ばれる
         expect(result).toBeDefined();
         expect(result.document.path).toBe('branchContext.json');
-        const document = JSON.parse(result.document.content);
+        expect(typeof result.document.content).toBe('object'); // Expect object
+        const document = result.document.content as any; // Use content directly and assert type
         // 期待値をフィクスチャの ID に合わせる
         expect(document.metadata.id).toBe('basic-branch-context');
       });

--- a/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
@@ -88,11 +88,11 @@ describe('ReadContextUseCase Integration Tests', () => {
       expect(Object.keys(result.globalMemory!).length).toBeGreaterThan(0);
       expect(result.globalMemory!['core/glossary.json']).toBeDefined();
 
-      const branchContextContent = result.branchMemory!['branchContext.json'];
-      expect(branchContextContent).toBeDefined();
-      const branchContext = JSON.parse(branchContextContent);
-      expect(branchContext.schema).toBe('memory_document_v2');
-      expect(branchContext.documentType).toBe('branch_context'); // トップレベルの documentType をチェック
+      const branchContext = result.branchMemory!['branchContext.json']; // Content is already an object
+      expect(branchContext).toBeDefined();
+      expect(typeof branchContext).toBe('object'); // Verify it's an object
+      expect((branchContext as any).schema).toBe('memory_document_v2');
+      expect((branchContext as any).documentType).toBe('branch_context'); // トップレベルの documentType をチェック
     });
 
     it('should get context regardless of language', async () => {
@@ -175,9 +175,10 @@ describe('ReadContextUseCase Integration Tests', () => {
       for (const coreFile of expectedCoreFiles) {
         expect(result.branchMemory![coreFile]).toBeDefined();
         try {
-          const content = JSON.parse(result.branchMemory![coreFile]);
-          expect(content.schema).toBe('memory_document_v2'); // スキーマ確認
-          expect(content.metadata.path).toBe(coreFile); // パス確認
+          const content = result.branchMemory![coreFile]; // Content is already an object
+          expect(typeof content).toBe('object'); // Verify it's an object
+          expect((content as any).schema).toBe('memory_document_v2'); // スキーマ確認
+          expect((content as any).metadata.path).toBe(coreFile); // パス確認
         } catch (e) {
           throw new Error(`Failed to parse JSON for ${coreFile}: ${e}`);
         }

--- a/packages/mcp/tests/integration/usecase/ReadGlobalDocumentUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadGlobalDocumentUseCase.integration.test.ts
@@ -37,16 +37,16 @@ describe('ReadGlobalDocumentUseCase Integration Tests', () => {
       expect(result).toBeDefined();
       expect(result.document).toBeDefined();
       expect(result.document.path).toBe('core/glossary.json');
-      expect(typeof result.document.content).toBe('string');
+      expect(typeof result.document.content).toBe('object'); // Expect object directly
 
-      const document = JSON.parse(result.document.content);
+      const document = result.document.content; // No need to parse
       expect(document).toHaveProperty('schema', 'memory_document_v2');
       // expect(document).toHaveProperty('documentType'); // documentType はトップレベルにはない
-      expect(document).toHaveProperty('metadata');
+      expect(document).toHaveProperty('metadata'); // Check property exists
       expect(document).toHaveProperty('content');
       // expect(document.documentType).toBe('core'); // トップレベルの documentType はチェックしない
-      expect(document.metadata).toHaveProperty('id', 'core-glossary-test'); // Update expected ID
-      expect(document.metadata).toHaveProperty('documentType', 'core'); // metadata 内の documentType をチェック
+      expect((document as any).metadata).toHaveProperty('id', 'core-glossary-test'); // Update expected ID & assert type
+      expect((document as any).metadata).toHaveProperty('documentType', 'core'); // metadata 内の documentType をチェック & assert type
     });
 
     it('should return an error if the document does not exist', async () => {
@@ -67,16 +67,18 @@ describe('ReadGlobalDocumentUseCase Integration Tests', () => {
       expect(planResult).toBeDefined();
       expect(planResult.document).toBeDefined();
       expect(planResult.document.path).toBe('plan-document.json');
-      const planDocument = JSON.parse(planResult.document.content);
-      expect(planDocument.metadata).toHaveProperty('documentType', 'plan'); // metadata 内の documentType をチェック
+      expect(typeof planResult.document.content).toBe('object'); // Expect object
+      const planDocument = planResult.document.content; // No need to parse
+      expect((planDocument as any).metadata).toHaveProperty('documentType', 'plan'); // metadata 内の documentType をチェック & assert type
 
       const guideResult = await useCase.execute({ path: 'guide-document.json' });
 
       expect(guideResult).toBeDefined();
       expect(guideResult.document).toBeDefined();
       expect(guideResult.document.path).toBe('guide-document.json');
-      const guideDocument = JSON.parse(guideResult.document.content);
-      expect(guideDocument.metadata).toHaveProperty('documentType', 'guide'); // metadata 内の documentType をチェック
+      expect(typeof guideResult.document.content).toBe('object'); // Expect object
+      const guideDocument = guideResult.document.content; // No need to parse
+      expect((guideDocument as any).metadata).toHaveProperty('documentType', 'guide'); // metadata 内の documentType をチェック & assert type
     });
   });
 });

--- a/packages/mcp/tests/unit/application/usecases/branch/ReadBranchDocumentUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/branch/ReadBranchDocumentUseCase.test.ts
@@ -81,7 +81,9 @@ describe('ReadBranchDocumentUseCase Unit Tests', () => {
     // 検証
     expect(result).toBeDefined();
     expect(result.document.path).toBe(docPath.value);
-    expect(result.document.content).toBe('{"key":"value"}');
+    // Expect the content to be the parsed object
+    const expectedContentObject = JSON.parse('{"key":"value"}');
+    expect(result.document.content).toEqual(expectedContentObject);
     expect(result.document.tags).toEqual(['test']);
     expect(mockBranchRepository.exists).toHaveBeenCalledWith(branchInfo.safeName);
     expect(mockBranchRepository.getDocument).toHaveBeenCalledWith(branchInfo, docPath);
@@ -155,7 +157,9 @@ describe('ReadBranchDocumentUseCase Unit Tests', () => {
 
     // 検証
     expect(result).toBeDefined();
-    expect(result.document.content).toBe('{"auto":"detected"}');
+    // Expect the content to be the parsed object
+    const expectedContentObjectDetected = JSON.parse('{"auto":"detected"}');
+    expect(result.document.content).toEqual(expectedContentObjectDetected);
     expect(mockGitService.getCurrentBranchName).toHaveBeenCalledTimes(1);
     expect(mockConfigProvider.getConfig).toHaveBeenCalledTimes(1);
     expect(mockBranchRepository.getDocument).toHaveBeenCalledWith(branchInfo, docPath);

--- a/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
@@ -96,14 +96,15 @@ describe('ReadContextUseCase Unit Tests', () => {
 
     // Assert
     expect(result.rules).toBeUndefined(); // rules should be undefined
+    // Expect parsed objects instead of strings
     expect(result.branchMemory).toEqual({
-      'progress.json': mockProgress.content,
-      'activeContext.json': mockActiveContext.content,
-      'branchContext.json': mockBranchContext.content,
-      'systemPatterns.json': mockSystemPatterns.content,
+      'progress.json': JSON.parse(mockProgress.content),
+      'activeContext.json': JSON.parse(mockActiveContext.content),
+      'branchContext.json': JSON.parse(mockBranchContext.content),
+      'systemPatterns.json': JSON.parse(mockSystemPatterns.content),
     });
     expect(result.globalMemory).toEqual({
-      [mockGlobalDocPath.value]: mockGlobalDoc.content,
+      [mockGlobalDocPath.value]: JSON.parse(mockGlobalDoc.content),
     });
 
     // expect(mockRulesRepo.getRules).toHaveBeenCalledWith(language, docsPath);

--- a/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadRulesUseCase.test.ts
@@ -4,14 +4,14 @@ import { Language } from '../../../../../src/domain/i18n/Language.js'; // ★追
 import { DomainError, DomainErrorCodes } from '../../../../../src/shared/errors/DomainError.js'; // DomainError もインポート
 import fs from 'fs/promises';
 import path from 'path';
-import { vi } from 'vitest'; // ★★★ vi をインポート ★★★
+import { vi, type Mocked } from 'vitest'; // ★★★ vi と Mocked をインポート ★★★
 import tmp from 'tmp-promise'; // tmp-promise をインポート
 
 describe('ReadRulesUseCase', () => {
   let useCase: ReadRulesUseCase;
   let tmpDir: tmp.DirectoryResult; // 一時ディレクトリ情報を保持する変数
   let rulesDir: string;
-  let mockTemplateService: vi.Mocked<TemplateService>; // ★モックを追加
+  let mockTemplateService: Mocked<TemplateService>; // ★モックを追加 (vi. を削除)
 
   const language = new Language('ja'); // Language オブジェクトを使う
   const mockRulesData = { id: 'rules', type: 'system', name: 'テストルール', sections: [{ id: 'sec1', title: 'セクション1', content: '内容1', isOptional: false }] }; // ダミーJSONオブジェクト
@@ -27,7 +27,7 @@ describe('ReadRulesUseCase', () => {
     mockTemplateService = {
       getTemplateAsJsonObject: vi.fn(),
       // 他の TemplateService メソッドのモックが必要ならここに追加
-    } as unknown as vi.Mocked<TemplateService>;
+    } as unknown as Mocked<TemplateService>; // (vi. を削除)
     useCase = new ReadRulesUseCase(rulesDir, mockTemplateService); // モックを注入
   });
 
@@ -36,7 +36,7 @@ describe('ReadRulesUseCase', () => {
     await tmpDir.cleanup(); // 手動でクリーンアップ
   });
 
-  it('should return rules content as JSON string when template is found', async () => {
+  it('should return rules content as object when template is found', async () => { // Test description updated
     // Arrange
     // モックの設定: getTemplateAsJsonObject が呼ばれたら mockRulesData を返す
     mockTemplateService.getTemplateAsJsonObject.mockResolvedValue(mockRulesData);
@@ -46,7 +46,7 @@ describe('ReadRulesUseCase', () => {
 
     // Assert
     expect(mockTemplateService.getTemplateAsJsonObject).toHaveBeenCalledWith('rules', language); // モックが正しく呼ばれたか
-    expect(result).toEqual({ content: mockRulesContent, language: language.code }); // JSON文字列と比較
+    expect(result).toEqual({ content: mockRulesData, language: language.code }); // Compare with object
   });
 
   // --- 以下のファイルパス依存のテストは不要になるため削除 ---

--- a/packages/mcp/tests/unit/application/usecases/global/ReadGlobalDocumentUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/global/ReadGlobalDocumentUseCase.test.ts
@@ -113,7 +113,9 @@ describe('ReadGlobalDocumentUseCase Unit Tests', () => {
     expect(result).not.toBeNull();
     expect(result?.document).toBeDefined();
     expect(result?.document?.path).toBe(mockDoc.path.value); // Check path from mock MemoryDocument
-    expect(result?.document?.content).toBe(mockDoc.content); // Check content from mock MemoryDocument
+    // Expect the content to be the parsed object, not the original string
+    const expectedContentObject = JSON.parse(mockDoc.content);
+    expect(result?.document?.content).toEqual(expectedContentObject); // Check parsed content object
     expect(result?.document?.tags).toEqual(mockDoc.tags.map(t => t.value)); // Check tags from mock MemoryDocument
     expect(result?.document?.lastModified).toBe(mockDoc.lastModified.toISOString()); // Check lastModified from mock MemoryDocument
     // Verify properties NOT included in DocumentDTO are undefined

--- a/packages/mcp/tests/unit/domain/entities/Tag.test.ts
+++ b/packages/mcp/tests/unit/domain/entities/Tag.test.ts
@@ -39,8 +39,9 @@ describe('Tag Unit Tests', () => {
 
     it('should throw an error for strings containing invalid characters (space)', () => {
       const invalidTag = 'invalid tag';
-      expect(() => Tag.create(invalidTag)).toThrow(
-        new DomainError(DomainErrorCodes.INVALID_TAG_FORMAT, 'Tag must contain only lowercase letters, numbers, and hyphens')
+      // Check only the error message string
+      expect(() => Tag.create(invalidTag)).toThrowError(
+        'Tag must contain only lowercase letters, numbers, and hyphens'
       );
     });
 


### PR DESCRIPTION
Closes #112

## Changes

- Modified `ReadGlobalDocumentUseCase`, `ReadBranchDocumentUseCase`, and `ReadContextUseCase` to automatically parse JSON content and return objects.
- Updated `DocumentDTO` and `ContextResult` types to allow `content` to be `string | object`.
- Confirmed that `DocumentWriterService` already handles formatting objects into pretty JSON strings on write, so no changes were needed for write use cases.
- Updated related integration tests (`Read*UseCase`, `Write*UseCase`, `ContextController`, `BranchController`, `GlobalController`) and unit tests (`Read*UseCase`) to reflect the new behavior.
- Fixed type errors in E2E tests (`branch-memory-bank`, `context`, `initialization`) caused by the type changes.
- Ensured all tests pass, including pre-push hooks.