### PR TITLE
Optimize read_context response for large memory banks (closes #114)

### DIFF
--- a/docs/global-memory-bank/_global_index.json
+++ b/docs/global-memory-bank/_global_index.json
@@ -2,7 +2,7 @@
   "schema": "tag_index_v1",
   "metadata": {
     "indexType": "global",
-    "lastUpdated": "2025-04-08T06:22:29.879Z",
+    "lastUpdated": "2025-04-08T07:52:18.532Z",
     "documentCount": 38,
     "tagCount": 56
   },
@@ -11,13 +11,13 @@
       "tag": "project",
       "documents": [
         {
-          "id": "e8e03cc6-8243-4c57-9086-0dcac4634a7c",
+          "id": "ff88c208-635f-4e92-ad3a-811af1b35d23",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "4c24ddbc-d115-4ab9-8eac-64a2e5a6904f",
+          "id": "3416ecc8-1e3b-4d15-98c7-f20a9171dcf3",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -28,85 +28,85 @@
       "tag": "documentation",
       "documents": [
         {
-          "id": "e8e03cc6-8243-4c57-9086-0dcac4634a7c",
+          "id": "ff88c208-635f-4e92-ad3a-811af1b35d23",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "8434a418-b7fe-4be8-8302-5e56fbf7ed70",
+          "id": "92184ae2-5103-4aaa-bfed-0e8c9c2a02c1",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "5d930441-28bc-4b3b-ae2e-816a829c8292",
+          "id": "60f07cb5-5924-4e82-a9f2-c3c5a64c6b95",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "f80b6cbf-d04c-4453-89a9-9ba9cddfc9a1",
+          "id": "9662865d-468f-440f-8cbd-920a3c17e9c6",
           "path": "04-guides/README.json",
           "title": "Guides Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "c37cf914-0365-4e10-bfd4-2f50e4836373",
+          "id": "93442a16-1146-486c-9330-9ccb3823f78f",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "1f439305-d386-4f32-8047-cc8be9493642",
+          "id": "aff7a204-dada-4744-abc5-4af62b8aeb9d",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "aa2af738-0f96-4f7e-8895-bb45f97bfa70",
+          "id": "9222d676-3271-49f1-8581-625ef7a20a67",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "cbb86650-55eb-408c-94a7-6de248aa2d0b",
+          "id": "2f5e4536-b7e3-47a5-b7ac-2c6bce730d9a",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "bec32b50-4ef8-4030-b0f2-017445bc190e",
+          "id": "51d32935-bd90-4f80-b53a-b3dd98c2f52b",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "06696ed7-4158-42ba-8df6-83727e873f26",
+          "id": "21ab2e86-2937-406f-b96c-65e04dafa1d7",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "73981567-fb90-409e-9c01-6d0d70db8d7b",
+          "id": "9fefaf55-20b5-4527-b16b-9c9257139c41",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "c5e87374-03ac-4105-a3f1-073c8d39ecda",
+          "id": "f0682741-6746-47b1-a74f-8dacecf6f4d1",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9670f92b-5ce8-4a98-bd8f-9cb8d9252f1a",
+          "id": "76331093-1e7f-4e76-9387-2ada889267e5",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -117,79 +117,79 @@
       "tag": "guide",
       "documents": [
         {
-          "id": "e8e03cc6-8243-4c57-9086-0dcac4634a7c",
+          "id": "ff88c208-635f-4e92-ad3a-811af1b35d23",
           "path": "01-project/README.json",
           "title": "Project Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "8434a418-b7fe-4be8-8302-5e56fbf7ed70",
+          "id": "92184ae2-5103-4aaa-bfed-0e8c9c2a02c1",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "5d930441-28bc-4b3b-ae2e-816a829c8292",
+          "id": "60f07cb5-5924-4e82-a9f2-c3c5a64c6b95",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "f80b6cbf-d04c-4453-89a9-9ba9cddfc9a1",
+          "id": "9662865d-468f-440f-8cbd-920a3c17e9c6",
           "path": "04-guides/README.json",
           "title": "Guides Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "c37cf914-0365-4e10-bfd4-2f50e4836373",
+          "id": "93442a16-1146-486c-9330-9ccb3823f78f",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "1f439305-d386-4f32-8047-cc8be9493642",
+          "id": "aff7a204-dada-4744-abc5-4af62b8aeb9d",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "cbb86650-55eb-408c-94a7-6de248aa2d0b",
+          "id": "2f5e4536-b7e3-47a5-b7ac-2c6bce730d9a",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "bec32b50-4ef8-4030-b0f2-017445bc190e",
+          "id": "51d32935-bd90-4f80-b53a-b3dd98c2f52b",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "06696ed7-4158-42ba-8df6-83727e873f26",
+          "id": "21ab2e86-2937-406f-b96c-65e04dafa1d7",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "832cfd9e-dae3-4a63-a1b4-cc7d033bc293",
+          "id": "66c23d49-7106-4e00-94e7-2e97970990fb",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "73981567-fb90-409e-9c01-6d0d70db8d7b",
+          "id": "9fefaf55-20b5-4527-b16b-9c9257139c41",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9670f92b-5ce8-4a98-bd8f-9cb8d9252f1a",
+          "id": "76331093-1e7f-4e76-9387-2ada889267e5",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -200,13 +200,13 @@
       "tag": "best-practices",
       "documents": [
         {
-          "id": "3d5c46d4-8397-4a52-9c87-b38fbbee4fe5",
+          "id": "b803c0a0-1b40-4fe7-af80-4d887c22d802",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "e3bc02a4-7d6b-4207-b34f-17b48d406683",
+          "id": "114e3941-cca6-4359-8f5d-76eb4492600b",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -217,13 +217,13 @@
       "tag": "typescript",
       "documents": [
         {
-          "id": "3d5c46d4-8397-4a52-9c87-b38fbbee4fe5",
+          "id": "b803c0a0-1b40-4fe7-af80-4d887c22d802",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "e3bc02a4-7d6b-4207-b34f-17b48d406683",
+          "id": "114e3941-cca6-4359-8f5d-76eb4492600b",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -234,13 +234,13 @@
       "tag": "clean-code",
       "documents": [
         {
-          "id": "3d5c46d4-8397-4a52-9c87-b38fbbee4fe5",
+          "id": "b803c0a0-1b40-4fe7-af80-4d887c22d802",
           "path": "01-project/coding-standards.json",
           "title": "Coding Standards",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "e3bc02a4-7d6b-4207-b34f-17b48d406683",
+          "id": "114e3941-cca6-4359-8f5d-76eb4492600b",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -251,7 +251,7 @@
       "tag": "overview",
       "documents": [
         {
-          "id": "4c24ddbc-d115-4ab9-8eac-64a2e5a6904f",
+          "id": "3416ecc8-1e3b-4d15-98c7-f20a9171dcf3",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -262,49 +262,49 @@
       "tag": "v2",
       "documents": [
         {
-          "id": "4c24ddbc-d115-4ab9-8eac-64a2e5a6904f",
+          "id": "3416ecc8-1e3b-4d15-98c7-f20a9171dcf3",
           "path": "01-project/project-overview.json",
           "title": "プロジェクト概要",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "40d6d485-92d0-474a-ab55-4b00c16ad3ee",
+          "id": "5662c985-671e-413a-9b51-5e10adf276d6",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3177c47c-e125-4f52-b519-48f52548d059",
+          "id": "cecf4584-dc24-4d1b-9834-b31647f77795",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3848291a-9c4b-44ac-bd13-241c4625397d",
+          "id": "2badc025-171d-47de-9b1c-71d4b8762a58",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "813954a2-3e54-4611-b0a9-945a00c65ea9",
+          "id": "1b6816b9-7e09-41de-9de2-8a4a0a943085",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "419c188f-2e7f-4c22-9ad4-21df96c1114e",
+          "id": "aba1e376-d84a-472c-a627-3712654c3a3a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "9235139e-b466-4079-989f-eb07c2ed2a84",
+          "id": "531ba507-5162-4685-9875-91e3a8e742ed",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "f34193bf-9f46-4606-9b48-3d3da62add98",
+          "id": "64bf8e95-3f35-4bf5-b6fd-8ece6b675710",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -315,7 +315,7 @@
       "tag": "tech-stack",
       "documents": [
         {
-          "id": "92ad2363-6207-47b6-a49b-7a4fb1684b71",
+          "id": "d9551aa8-3afe-45b3-811e-c296b08723a5",
           "path": "01-project/tech-stack.json",
           "title": "Technology Stack",
           "lastModified": "2025-04-05T05:55:52.846Z"
@@ -326,13 +326,13 @@
       "tag": "infrastructure",
       "documents": [
         {
-          "id": "92ad2363-6207-47b6-a49b-7a4fb1684b71",
+          "id": "d9551aa8-3afe-45b3-811e-c296b08723a5",
           "path": "01-project/tech-stack.json",
           "title": "Technology Stack",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "cbb86650-55eb-408c-94a7-6de248aa2d0b",
+          "id": "2f5e4536-b7e3-47a5-b7ac-2c6bce730d9a",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -343,25 +343,25 @@
       "tag": "architecture",
       "documents": [
         {
-          "id": "8434a418-b7fe-4be8-8302-5e56fbf7ed70",
+          "id": "92184ae2-5103-4aaa-bfed-0e8c9c2a02c1",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "40d6d485-92d0-474a-ab55-4b00c16ad3ee",
+          "id": "5662c985-671e-413a-9b51-5e10adf276d6",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "9235139e-b466-4079-989f-eb07c2ed2a84",
+          "id": "531ba507-5162-4685-9875-91e3a8e742ed",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "627b9077-7017-43c7-8757-87e8826d7dc9",
+          "id": "4f42d6d9-8adf-4e7e-9540-5a61d79b88f8",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -372,31 +372,31 @@
       "tag": "design",
       "documents": [
         {
-          "id": "8434a418-b7fe-4be8-8302-5e56fbf7ed70",
+          "id": "92184ae2-5103-4aaa-bfed-0e8c9c2a02c1",
           "path": "02-architecture/README.json",
           "title": "Architecture Directory README",
           "lastModified": "2025-04-05T05:55:52.846Z"
         },
         {
-          "id": "40d6d485-92d0-474a-ab55-4b00c16ad3ee",
+          "id": "5662c985-671e-413a-9b51-5e10adf276d6",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3177c47c-e125-4f52-b519-48f52548d059",
+          "id": "cecf4584-dc24-4d1b-9834-b31647f77795",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "9235139e-b466-4079-989f-eb07c2ed2a84",
+          "id": "531ba507-5162-4685-9875-91e3a8e742ed",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "5b6e6426-1be4-4dbd-ac1a-bc9ad2dadf7f",
+          "id": "404a64e0-9594-4d3e-b5f5-71c9a8184cff",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -407,13 +407,13 @@
       "tag": "decision",
       "documents": [
         {
-          "id": "40d6d485-92d0-474a-ab55-4b00c16ad3ee",
+          "id": "5662c985-671e-413a-9b51-5e10adf276d6",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "9235139e-b466-4079-989f-eb07c2ed2a84",
+          "id": "531ba507-5162-4685-9875-91e3a8e742ed",
           "path": "06-releases/v2-design-decisions.json",
           "title": "v2.0 設計上の決定事項",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -424,13 +424,13 @@
       "tag": "json",
       "documents": [
         {
-          "id": "40d6d485-92d0-474a-ab55-4b00c16ad3ee",
+          "id": "5662c985-671e-413a-9b51-5e10adf276d6",
           "path": "02-architecture/consolidated-architecture.json",
           "title": "統合アーキテクチャドキュメント",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "f34193bf-9f46-4606-9b48-3d3da62add98",
+          "id": "64bf8e95-3f35-4bf5-b6fd-8ece6b675710",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -441,13 +441,13 @@
       "tag": "analysis",
       "documents": [
         {
-          "id": "cc5b402e-4c00-419a-b21f-0baa2be9ad9f",
+          "id": "c4b8bdf3-1c32-4de3-a682-031f367c5946",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -458,37 +458,37 @@
       "tag": "memory-bank",
       "documents": [
         {
-          "id": "cc5b402e-4c00-419a-b21f-0baa2be9ad9f",
+          "id": "c4b8bdf3-1c32-4de3-a682-031f367c5946",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "facf12af-6cae-4a1f-9489-8cfd99ef865d",
+          "id": "ea03e7f6-0022-4ef3-b7f2-a151450495a4",
           "path": "07-infrastructure/ci-cd/memory-bank-errors.json",
           "title": "Memory Bank Error Troubleshooting",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "5b6e6426-1be4-4dbd-ac1a-bc9ad2dadf7f",
+          "id": "404a64e0-9594-4d3e-b5f5-71c9a8184cff",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "cee81024-0113-49ef-af8d-2b028889a6be",
+          "id": "a2a97e11-40c6-4bdb-9bfe-7588b73828b7",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3c5c8387-8bf2-48c2-b2ce-f6b17b79b055",
+          "id": "12d9e629-fcba-4f03-9848-a6eafcc766ef",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -499,7 +499,7 @@
       "tag": "organization",
       "documents": [
         {
-          "id": "cc5b402e-4c00-419a-b21f-0baa2be9ad9f",
+          "id": "c4b8bdf3-1c32-4de3-a682-031f367c5946",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -510,49 +510,49 @@
       "tag": "meta",
       "documents": [
         {
-          "id": "cc5b402e-4c00-419a-b21f-0baa2be9ad9f",
+          "id": "c4b8bdf3-1c32-4de3-a682-031f367c5946",
           "path": "02-architecture/global-memory-bank-organized-analysis.json",
           "title": "グローバルメモリバンク 整理分析",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "73981567-fb90-409e-9c01-6d0d70db8d7b",
+          "id": "9fefaf55-20b5-4527-b16b-9c9257139c41",
           "path": "meta/README.json",
           "title": "Meta Directory README",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "c5e87374-03ac-4105-a3f1-073c8d39ecda",
+          "id": "f0682741-6746-47b1-a74f-8dacecf6f4d1",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9670f92b-5ce8-4a98-bd8f-9cb8d9252f1a",
+          "id": "76331093-1e7f-4e76-9387-2ada889267e5",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "261f8d80-2d05-4903-a186-0b230143870c",
+          "id": "df27c53c-e21c-4211-9d47-57b10e6e1179",
           "path": "tags/index.json",
           "title": "タグインデックス",
           "lastModified": "2025-04-08T04:44:04.926Z"
         },
         {
-          "id": "cee81024-0113-49ef-af8d-2b028889a6be",
+          "id": "a2a97e11-40c6-4bdb-9bfe-7588b73828b7",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3c5c8387-8bf2-48c2-b2ce-f6b17b79b055",
+          "id": "12d9e629-fcba-4f03-9848-a6eafcc766ef",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -563,25 +563,25 @@
       "tag": "implementation",
       "documents": [
         {
-          "id": "5d930441-28bc-4b3b-ae2e-816a829c8292",
+          "id": "60f07cb5-5924-4e82-a9f2-c3c5a64c6b95",
           "path": "03-implementation/README.json",
           "title": "Implementation Directory README",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3848291a-9c4b-44ac-bd13-241c4625397d",
+          "id": "2badc025-171d-47de-9b1c-71d4b8762a58",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "813954a2-3e54-4611-b0a9-945a00c65ea9",
+          "id": "1b6816b9-7e09-41de-9de2-8a4a0a943085",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "f34193bf-9f46-4606-9b48-3d3da62add98",
+          "id": "64bf8e95-3f35-4bf5-b6fd-8ece6b675710",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -592,19 +592,19 @@
       "tag": "mcp",
       "documents": [
         {
-          "id": "3177c47c-e125-4f52-b519-48f52548d059",
+          "id": "cecf4584-dc24-4d1b-9834-b31647f77795",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3848291a-9c4b-44ac-bd13-241c4625397d",
+          "id": "2badc025-171d-47de-9b1c-71d4b8762a58",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "832cfd9e-dae3-4a63-a1b4-cc7d033bc293",
+          "id": "66c23d49-7106-4e00-94e7-2e97970990fb",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -615,13 +615,13 @@
       "tag": "command",
       "documents": [
         {
-          "id": "3177c47c-e125-4f52-b519-48f52548d059",
+          "id": "cecf4584-dc24-4d1b-9834-b31647f77795",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3848291a-9c4b-44ac-bd13-241c4625397d",
+          "id": "2badc025-171d-47de-9b1c-71d4b8762a58",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -632,13 +632,13 @@
       "tag": "context",
       "documents": [
         {
-          "id": "3177c47c-e125-4f52-b519-48f52548d059",
+          "id": "cecf4584-dc24-4d1b-9834-b31647f77795",
           "path": "03-implementation/read-context-command-design.json",
           "title": "`read_context`コマンド設計書",
           "lastModified": "2025-04-05T05:55:52.847Z"
         },
         {
-          "id": "3848291a-9c4b-44ac-bd13-241c4625397d",
+          "id": "2badc025-171d-47de-9b1c-71d4b8762a58",
           "path": "03-implementation/read-context-command-implementation.json",
           "title": "`read_context`コマンド実装ガイド",
           "lastModified": "2025-04-05T05:55:52.847Z"
@@ -649,13 +649,13 @@
       "tag": "testing",
       "documents": [
         {
-          "id": "c37cf914-0365-4e10-bfd4-2f50e4836373",
+          "id": "93442a16-1146-486c-9330-9ccb3823f78f",
           "path": "05-testing/README.json",
           "title": "Testing Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "1b88ef57-7a2f-434e-98d0-c14c5b2d61fc",
+          "id": "795aaa12-81f7-4e9f-815c-08569f61ea32",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -666,7 +666,7 @@
       "tag": "e2e",
       "documents": [
         {
-          "id": "1b88ef57-7a2f-434e-98d0-c14c5b2d61fc",
+          "id": "795aaa12-81f7-4e9f-815c-08569f61ea32",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -677,13 +677,13 @@
       "tag": "integration-test",
       "documents": [
         {
-          "id": "1b88ef57-7a2f-434e-98d0-c14c5b2d61fc",
+          "id": "795aaa12-81f7-4e9f-815c-08569f61ea32",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "5b6e6426-1be4-4dbd-ac1a-bc9ad2dadf7f",
+          "id": "404a64e0-9594-4d3e-b5f5-71c9a8184cff",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -694,7 +694,7 @@
       "tag": "tdd",
       "documents": [
         {
-          "id": "1b88ef57-7a2f-434e-98d0-c14c5b2d61fc",
+          "id": "795aaa12-81f7-4e9f-815c-08569f61ea32",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -705,7 +705,7 @@
       "tag": "qa",
       "documents": [
         {
-          "id": "1b88ef57-7a2f-434e-98d0-c14c5b2d61fc",
+          "id": "795aaa12-81f7-4e9f-815c-08569f61ea32",
           "path": "05-testing/consolidated-test-strategy.json",
           "title": "Memory Bank テスト戦略統合ドキュメント",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -716,31 +716,31 @@
       "tag": "release",
       "documents": [
         {
-          "id": "1f439305-d386-4f32-8047-cc8be9493642",
+          "id": "aff7a204-dada-4744-abc5-4af62b8aeb9d",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "813954a2-3e54-4611-b0a9-945a00c65ea9",
+          "id": "1b6816b9-7e09-41de-9de2-8a4a0a943085",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "419c188f-2e7f-4c22-9ad4-21df96c1114e",
+          "id": "aba1e376-d84a-472c-a627-3712654c3a3a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "aa2af738-0f96-4f7e-8895-bb45f97bfa70",
+          "id": "9222d676-3271-49f1-8581-625ef7a20a67",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "0618632c-edee-453d-a5ff-46278b116367",
+          "id": "4e975824-926e-4021-878a-1cd0d417db2b",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -751,7 +751,7 @@
       "tag": "version",
       "documents": [
         {
-          "id": "1f439305-d386-4f32-8047-cc8be9493642",
+          "id": "aff7a204-dada-4744-abc5-4af62b8aeb9d",
           "path": "06-releases/README.json",
           "title": "Releases Directory README",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -762,13 +762,13 @@
       "tag": "planning",
       "documents": [
         {
-          "id": "813954a2-3e54-4611-b0a9-945a00c65ea9",
+          "id": "1b6816b9-7e09-41de-9de2-8a4a0a943085",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "0618632c-edee-453d-a5ff-46278b116367",
+          "id": "4e975824-926e-4021-878a-1cd0d417db2b",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -779,13 +779,13 @@
       "tag": "changelog",
       "documents": [
         {
-          "id": "813954a2-3e54-4611-b0a9-945a00c65ea9",
+          "id": "1b6816b9-7e09-41de-9de2-8a4a0a943085",
           "path": "06-releases/consolidated-v2-release.json",
           "title": "Memory Bank 2.0 統合リリース情報",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "419c188f-2e7f-4c22-9ad4-21df96c1114e",
+          "id": "aba1e376-d84a-472c-a627-3712654c3a3a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -796,7 +796,7 @@
       "tag": "pr",
       "documents": [
         {
-          "id": "419c188f-2e7f-4c22-9ad4-21df96c1114e",
+          "id": "aba1e376-d84a-472c-a627-3712654c3a3a",
           "path": "06-releases/release-v2.0.0.json",
           "title": "リリース v2.0.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -807,7 +807,7 @@
       "tag": "v2-2-0",
       "documents": [
         {
-          "id": "aa2af738-0f96-4f7e-8895-bb45f97bfa70",
+          "id": "9222d676-3271-49f1-8581-625ef7a20a67",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -818,7 +818,7 @@
       "tag": "json-patch",
       "documents": [
         {
-          "id": "aa2af738-0f96-4f7e-8895-bb45f97bfa70",
+          "id": "9222d676-3271-49f1-8581-625ef7a20a67",
           "path": "06-releases/release-v2.2.0.json",
           "title": "リリースノート v2.2.0",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -829,13 +829,13 @@
       "tag": "plan",
       "documents": [
         {
-          "id": "f34193bf-9f46-4606-9b48-3d3da62add98",
+          "id": "64bf8e95-3f35-4bf5-b6fd-8ece6b675710",
           "path": "06-releases/v2-implementation-plan.json",
           "title": "Memory Bank 2.0: 実装計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
         },
         {
-          "id": "3c5c8387-8bf2-48c2-b2ce-f6b17b79b055",
+          "id": "12d9e629-fcba-4f03-9848-a6eafcc766ef",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -846,7 +846,7 @@
       "tag": "v2-1-0",
       "documents": [
         {
-          "id": "0618632c-edee-453d-a5ff-46278b116367",
+          "id": "4e975824-926e-4021-878a-1cd0d417db2b",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -857,7 +857,7 @@
       "tag": "json-migration",
       "documents": [
         {
-          "id": "0618632c-edee-453d-a5ff-46278b116367",
+          "id": "4e975824-926e-4021-878a-1cd0d417db2b",
           "path": "06-releases/v2.1.0-release-plan.json",
           "title": "Memory Bank v2.1.0 リリース計画",
           "lastModified": "2025-04-05T05:55:52.848Z"
@@ -868,7 +868,7 @@
       "tag": "operations",
       "documents": [
         {
-          "id": "cbb86650-55eb-408c-94a7-6de248aa2d0b",
+          "id": "2f5e4536-b7e3-47a5-b7ac-2c6bce730d9a",
           "path": "07-infrastructure/README.json",
           "title": "Infrastructure Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -879,7 +879,7 @@
       "tag": "troubleshooting",
       "documents": [
         {
-          "id": "facf12af-6cae-4a1f-9489-8cfd99ef865d",
+          "id": "ea03e7f6-0022-4ef3-b7f2-a151450495a4",
           "path": "07-infrastructure/ci-cd/memory-bank-errors.json",
           "title": "Memory Bank Error Troubleshooting",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -890,7 +890,7 @@
       "tag": "ci-cd",
       "documents": [
         {
-          "id": "1d1ccce4-ca13-4e6a-986e-a224e5b5d272",
+          "id": "2624366a-b9a5-4e6d-bdc0-23b5f9866a89",
           "path": "07-infrastructure/ci-cd/workflows.json",
           "title": "CI/CD Workflows",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -901,7 +901,7 @@
       "tag": "i18n",
       "documents": [
         {
-          "id": "bec32b50-4ef8-4030-b0f2-017445bc190e",
+          "id": "51d32935-bd90-4f80-b53a-b3dd98c2f52b",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -912,7 +912,7 @@
       "tag": "l10n",
       "documents": [
         {
-          "id": "bec32b50-4ef8-4030-b0f2-017445bc190e",
+          "id": "51d32935-bd90-4f80-b53a-b3dd98c2f52b",
           "path": "08-i18n/README.json",
           "title": "Internationalization Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -923,13 +923,13 @@
       "tag": "refactoring",
       "documents": [
         {
-          "id": "06696ed7-4158-42ba-8df6-83727e873f26",
+          "id": "21ab2e86-2937-406f-b96c-65e04dafa1d7",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "5b6e6426-1be4-4dbd-ac1a-bc9ad2dadf7f",
+          "id": "404a64e0-9594-4d3e-b5f5-71c9a8184cff",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -940,13 +940,13 @@
       "tag": "tech-debt",
       "documents": [
         {
-          "id": "06696ed7-4158-42ba-8df6-83727e873f26",
+          "id": "21ab2e86-2937-406f-b96c-65e04dafa1d7",
           "path": "09-refactoring/README.json",
           "title": "Refactoring Directory README",
           "lastModified": "2025-04-05T05:55:52.849Z"
         },
         {
-          "id": "5b6e6426-1be4-4dbd-ac1a-bc9ad2dadf7f",
+          "id": "404a64e0-9594-4d3e-b5f5-71c9a8184cff",
           "path": "09-refactoring/json-global-design-issues.json",
           "title": "json-global-design-issues.json",
           "lastModified": "2025-04-05T05:55:52.849Z"
@@ -957,7 +957,7 @@
       "tag": "system-design",
       "documents": [
         {
-          "id": "627b9077-7017-43c7-8757-87e8826d7dc9",
+          "id": "4f42d6d9-8adf-4e7e-9540-5a61d79b88f8",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -968,25 +968,25 @@
       "tag": "core",
       "documents": [
         {
-          "id": "627b9077-7017-43c7-8757-87e8826d7dc9",
+          "id": "4f42d6d9-8adf-4e7e-9540-5a61d79b88f8",
           "path": "core/architecture.json",
           "title": "システムアーキテクチャ基本情報",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "e3bc02a4-7d6b-4207-b34f-17b48d406683",
+          "id": "114e3941-cca6-4359-8f5d-76eb4492600b",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "dcf363c2-1ada-468b-b01f-6333778540d8",
+          "id": "c804406e-a37f-4557-ab0c-a3437f76c5e0",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "832cfd9e-dae3-4a63-a1b4-cc7d033bc293",
+          "id": "66c23d49-7106-4e00-94e7-2e97970990fb",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -997,13 +997,13 @@
       "tag": "standards",
       "documents": [
         {
-          "id": "e3bc02a4-7d6b-4207-b34f-17b48d406683",
+          "id": "114e3941-cca6-4359-8f5d-76eb4492600b",
           "path": "core/coding-standards.json",
           "title": "コーディング規約",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "c5e87374-03ac-4105-a3f1-073c8d39ecda",
+          "id": "f0682741-6746-47b1-a74f-8dacecf6f4d1",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1014,7 +1014,7 @@
       "tag": "glossary",
       "documents": [
         {
-          "id": "dcf363c2-1ada-468b-b01f-6333778540d8",
+          "id": "c804406e-a37f-4557-ab0c-a3437f76c5e0",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1025,7 +1025,7 @@
       "tag": "terminology",
       "documents": [
         {
-          "id": "dcf363c2-1ada-468b-b01f-6333778540d8",
+          "id": "c804406e-a37f-4557-ab0c-a3437f76c5e0",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1036,7 +1036,7 @@
       "tag": "definitions",
       "documents": [
         {
-          "id": "dcf363c2-1ada-468b-b01f-6333778540d8",
+          "id": "c804406e-a37f-4557-ab0c-a3437f76c5e0",
           "path": "core/glossary.json",
           "title": "用語集",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1047,7 +1047,7 @@
       "tag": "manual",
       "documents": [
         {
-          "id": "832cfd9e-dae3-4a63-a1b4-cc7d033bc293",
+          "id": "66c23d49-7106-4e00-94e7-2e97970990fb",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1058,7 +1058,7 @@
       "tag": "en",
       "documents": [
         {
-          "id": "832cfd9e-dae3-4a63-a1b4-cc7d033bc293",
+          "id": "66c23d49-7106-4e00-94e7-2e97970990fb",
           "path": "core/mcp-tool-manual.json",
           "title": "MCP Tool Manual (English)",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1069,7 +1069,7 @@
       "tag": "navigation",
       "documents": [
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
@@ -1080,19 +1080,19 @@
       "tag": "reference",
       "documents": [
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "c5e87374-03ac-4105-a3f1-073c8d39ecda",
+          "id": "f0682741-6746-47b1-a74f-8dacecf6f4d1",
           "path": "meta/document-type-standards.json",
           "title": "標準ドキュメントタイプ定義",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "cee81024-0113-49ef-af8d-2b028889a6be",
+          "id": "a2a97e11-40c6-4bdb-9bfe-7588b73828b7",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -1103,31 +1103,31 @@
       "tag": "index",
       "documents": [
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9670f92b-5ce8-4a98-bd8f-9cb8d9252f1a",
+          "id": "76331093-1e7f-4e76-9387-2ada889267e5",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "261f8d80-2d05-4903-a186-0b230143870c",
+          "id": "df27c53c-e21c-4211-9d47-57b10e6e1179",
           "path": "tags/index.json",
           "title": "タグインデックス",
           "lastModified": "2025-04-08T04:44:04.926Z"
         },
         {
-          "id": "cee81024-0113-49ef-af8d-2b028889a6be",
+          "id": "a2a97e11-40c6-4bdb-9bfe-7588b73828b7",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3c5c8387-8bf2-48c2-b2ce-f6b17b79b055",
+          "id": "12d9e629-fcba-4f03-9848-a6eafcc766ef",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"
@@ -1138,25 +1138,25 @@
       "tag": "tag",
       "documents": [
         {
-          "id": "6bc20507-1d29-47be-9d74-e43502b807a0",
+          "id": "00f2f934-d11a-4010-bb55-f644854e5717",
           "path": "meta/consolidated-memory-bank-meta.json",
           "title": "Consolidated Memory Bank Meta Information",
           "lastModified": "2025-04-05T05:55:52.850Z"
         },
         {
-          "id": "9670f92b-5ce8-4a98-bd8f-9cb8d9252f1a",
+          "id": "76331093-1e7f-4e76-9387-2ada889267e5",
           "path": "tags/README.json",
           "title": "Tags Directory README",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "cee81024-0113-49ef-af8d-2b028889a6be",
+          "id": "a2a97e11-40c6-4bdb-9bfe-7588b73828b7",
           "path": "tags/tag_categorization.json",
           "title": "タグカテゴリ定義",
           "lastModified": "2025-04-05T05:55:52.851Z"
         },
         {
-          "id": "3c5c8387-8bf2-48c2-b2ce-f6b17b79b055",
+          "id": "12d9e629-fcba-4f03-9848-a6eafcc766ef",
           "path": "tags/tag_index_update_plan.json",
           "title": "タグインデックス更新計画",
           "lastModified": "2025-04-05T05:55:52.851Z"

--- a/packages/mcp/src/application/usecases/common/ReadContextUseCase.ts
+++ b/packages/mcp/src/application/usecases/common/ReadContextUseCase.ts
@@ -1,4 +1,5 @@
 import { BranchInfo } from "../../../domain/entities/BranchInfo.js";
+import { DocumentPath } from "../../../domain/entities/DocumentPath.js";
 import type { IBranchMemoryBankRepository } from "../../../domain/repositories/IBranchMemoryBankRepository.js";
 import type { IGlobalMemoryBankRepository } from "../../../domain/repositories/IGlobalMemoryBankRepository.js";
 import { DomainError, DomainErrorCodes } from "../../../shared/errors/DomainError.js";
@@ -12,176 +13,103 @@ export type ContextRequest = {
 
 export type ContextResult = {
   rules?: RulesResult;
-  branchMemory?: Record<string, string | object>; // Allow object
-  globalMemory?: Record<string, string | object>; // Allow object
+  branchMemory: {
+    coreFiles: {
+      'branchContext.json': object;
+      'activeContext.json': object;
+      'progress.json': object;
+      'systemPatterns.json': object;
+    };
+    availableFiles: string[];
+  };
+  globalMemory: {
+    coreFiles: Record<string, object>;
+    availableFiles: string[];
+  };
 };
 
 /**
  * Context Reading Use Case
  */
 export class ReadContextUseCase {
-  /**
-   * Constructor
-   * @param branchRepository Branch memory bank repository
-   * @param globalRepository Global memory bank repository
-   */
   constructor(
     private readonly branchRepository: IBranchMemoryBankRepository,
     private readonly globalRepository: IGlobalMemoryBankRepository
   ) { }
 
-  /**
-   * Read context based on specified branch and options
-   * @param request Context request
-   * @returns Context result
-   * @throws When branch does not exist
-   */
   async execute(request: ContextRequest): Promise<ContextResult> {
     const { branch } = request;
-    const result: ContextResult = {};
-
-    // Add debug log (using logger)
-    logger.debug(`ReadContextUseCase.execute: ${JSON.stringify(request, null, 2)}`);
-    logger.debug(`Repository details: branchRepository=${this.branchRepository.constructor.name}, globalRepository=${this.globalRepository.constructor.name}`);
-    logger.debug('Entering try block in ReadContextUseCase.execute'); // Added log
+    const result: ContextResult = {
+      branchMemory: {
+        coreFiles: {
+          'branchContext.json': {},
+          'activeContext.json': {},
+          'progress.json': {},
+          'systemPatterns.json': {}
+        },
+        availableFiles: []
+      },
+      globalMemory: {
+        coreFiles: {},
+        availableFiles: []
+      }
+    };
 
     try {
       // Check branch existence
-      logger.info(`Checking branch existence: ${branch}`);
       const branchExists = await this.branchRepository.exists(branch);
-      logger.debug(`Branch ${branch} exists: ${branchExists}`);
-      logger.debug('Finished checking branch existence'); // Added log
-
       if (!branchExists) {
-        logger.info(`Branch ${branch} not found, attempting auto-initialization...`); // Modified log
         try {
           const branchInfo = BranchInfo.create(branch);
-          logger.debug('Calling branchRepository.initialize...'); // Added log
           await this.branchRepository.initialize(branchInfo);
-          logger.info(`Branch ${branch} auto-initialized successfully`);
-          logger.debug('Finished branchRepository.initialize'); // Added log
         } catch (initError) {
-          logger.error(`Failed to auto-initialize branch ${branch}:`, initError);
           throw new DomainError(
             DomainErrorCodes.BRANCH_INITIALIZATION_FAILED,
-            `Failed to auto-initialize branch: ${branch} - ${initError instanceof Error ? initError.message : 'Unknown error'}`
+            `Failed to auto-initialize branch: ${branch}`
           );
         }
       }
 
       // Read branch memory
-      logger.info(`Reading branch memory for: ${branch}`);
-      logger.debug('Calling readBranchMemory...'); // Added log
-      result.branchMemory = await this.readBranchMemory(branch);
-      logger.debug(`Branch memory keys: ${Object.keys(result.branchMemory).join(', ')}`);
-      logger.debug('Finished readBranchMemory'); // Added log
+      const branchInfo = BranchInfo.create(branch);
+      const branchPaths = await this.branchRepository.listDocuments(branchInfo);
+      result.branchMemory.availableFiles = branchPaths.map(p => p.value);
 
-      // Read global memory (core files only)
-      logger.info(`Reading global memory (core files only)`);
-      logger.debug('Calling readGlobalMemory...'); // Added log
-      result.globalMemory = await this.readGlobalMemory();
-      logger.debug(`Global memory keys: ${Object.keys(result.globalMemory || {}).join(', ')}`);
-      logger.debug('Finished readGlobalMemory'); // Added log
+      // Read core branch files
+      const coreBranchFiles = ['branchContext.json', 'activeContext.json', 'progress.json', 'systemPatterns.json'];
+      for (const file of coreBranchFiles) {
+        const path = DocumentPath.create(file);
+        try {
+          const doc = await this.branchRepository.getDocument(branchInfo, path);
+          if (doc) {
+            result.branchMemory.coreFiles[file as keyof typeof result.branchMemory.coreFiles] =
+              JSON.parse(doc.content);
+          }
+        } catch (error) {
+          logger.error(`Error reading ${file}: ${error}`);
+        }
+      }
 
-      logger.debug('Exiting try block in ReadContextUseCase.execute successfully'); // Added log
+      // Read global memory
+      const globalPaths = await this.globalRepository.listDocuments();
+      result.globalMemory.availableFiles = globalPaths.map(p => p.value);
+
+      const coreGlobalPaths = globalPaths.filter(p => p.value.startsWith('core/'));
+      for (const path of coreGlobalPaths) {
+        try {
+          const doc = await this.globalRepository.getDocument(path);
+          if (doc) {
+            result.globalMemory.coreFiles[path.value] = JSON.parse(doc.content);
+          }
+        } catch (error) {
+          logger.error(`Error reading ${path.value}: ${error}`);
+        }
+      }
+
       return result;
     } catch (error) {
-      logger.error(`ReadContextUseCase error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      logger.error(`Error details: ${error instanceof Error ? error.stack : 'No stack trace available'}`);
+      logger.error(`ReadContextUseCase error: ${error}`);
       throw error;
     }
-  }
-
-  /**
-   * Read branch memory
-   * @param branchName Branch name
-   * @returns Object with document paths as keys and content as values
-   */
-  private async readBranchMemory(branchName: string): Promise<Record<string, string | object>> { // Update return type
-    const branchInfo = BranchInfo.create(branchName);
-    logger.debug('Calling branchRepository.listDocuments...'); // Added log
-
-    await new Promise(resolve => setTimeout(resolve, 200)); // さらに待機時間を増やしてみる (200ms)
-
-    const paths = await this.branchRepository.listDocuments(branchInfo);
-    logger.debug('Finished branchRepository.listDocuments'); // Added log
-    // Debug log removed by Mirai
-    const result: Record<string, string | object> = {}; // Update result type
-    logger.debug(`Reading branch memory paths: ${paths.map(p => p.value).join(', ')}`);
-
-    for (const path of paths) {
-      logger.debug(`Reading branch document: ${path.value}`);
-      try {
-        logger.debug('Calling branchRepository.getDocument...'); // Added log
-        const document = await this.branchRepository.getDocument(branchInfo, path);
-        logger.debug('Finished branchRepository.getDocument'); // Added log
-        if (document) {
-          logger.debug(`Document found: ${path.value}`);
-          // Attempt to parse content as JSON
-          let content: string | object;
-          try {
-            content = JSON.parse(document.content);
-            logger.debug(`Parsed branch document: ${path.value}`);
-          } catch (e) {
-            logger.debug(`Failed to parse branch document as JSON, keeping as string: ${path.value}`);
-            content = document.content; // Keep original string if parsing fails
-          }
-          result[path.value] = content;
-        } else {
-          logger.warn(`Document not found: ${path.value}`);
-        }
-      } catch (error) {
-        logger.error(`Error reading branch document ${path.value}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        // Continue processing even if a single document fails
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Read global memory (core files only)
-   * @returns Object with document paths as keys and content as values
-   */
-  private async readGlobalMemory(): Promise<Record<string, string | object>> { // Update return type
-    logger.debug('Calling globalRepository.listDocuments...'); // Added log
-    let paths = await this.globalRepository.listDocuments();
-    logger.debug('Finished globalRepository.listDocuments'); // Added log
-    const result: Record<string, string | object> = {}; // Update result type
-
-    // Filter for core files only
-    logger.debug('Filtering for core files only');
-    paths = paths.filter(p => p.value.startsWith('core/'));
-
-    logger.debug(`Reading global memory paths: ${paths.map(p => p.value).join(', ')}`);
-
-    for (const path of paths) {
-      logger.debug(`Reading global document: ${path.value}`);
-      try {
-        logger.debug('Calling globalRepository.getDocument...'); // Added log
-        const document = await this.globalRepository.getDocument(path);
-        logger.debug('Finished globalRepository.getDocument'); // Added log
-        if (document) {
-          logger.debug(`Document found: ${path.value}`);
-          // Attempt to parse content as JSON
-          let content: string | object;
-          try {
-            content = JSON.parse(document.content);
-            logger.debug(`Parsed global document: ${path.value}`);
-          } catch (e) {
-            logger.debug(`Failed to parse global document as JSON, keeping as string: ${path.value}`);
-            content = document.content; // Keep original string if parsing fails
-          }
-          result[path.value] = content;
-        } else {
-          logger.warn(`Document not found: ${path.value}`);
-        }
-      } catch (error) {
-        logger.error(`Error reading global document ${path.value}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        // Continue processing even if a single document fails
-      }
-    }
-
-    return result;
   }
 }

--- a/packages/mcp/tests/integration/controller/ContextController.integration.test.ts
+++ b/packages/mcp/tests/integration/controller/ContextController.integration.test.ts
@@ -3,35 +3,24 @@
  */
 import { setupTestEnv, cleanupTestEnv, createBranchDir, type TestEnv } from '../helpers/test-env.js';
 import { loadBranchFixture, loadGlobalFixture } from '../helpers/fixtures-loader.js';
-// import { Application } from '../mocks/Application'; // Removed mock application
 import * as path from 'path';
-import { DIContainer, setupContainer } from '../../../src/main/di/providers.js'; // Import DI container and setup function
-import { ContextController } from '../../../src/interface/controllers/ContextController.js'; // Import real controller
-import type { ContextRequest } from '../../../src/application/usecases/types.js'; // Import request type if needed
+import { DIContainer, setupContainer } from '../../../src/main/di/providers.js';
+import { ContextController } from '../../../src/interface/controllers/ContextController.js';
+import type { ContextRequest } from '../../../src/application/usecases/types.js';
 
 describe('ContextController Integration Tests', () => {
   let testEnv: TestEnv;
-  // let app: Application; // Removed mock application instance
-  let container: DIContainer; // Use DI container
+  let container: DIContainer;
   const TEST_BRANCH = 'feature/test-branch';
 
   beforeEach(async () => {
-    // Setup test environment
     testEnv = await setupTestEnv();
-    // beforeEach でブランチディレクトリを作成しないように変更
-    // (自動初期化のテストのため)
-    // await createBranchDir(testEnv, TEST_BRANCH);
-    // Initialize DI container with test configuration
     container = await setupContainer({ docsRoot: testEnv.docRoot });
-    // Set log level to debug for testing
     const { logger } = await import('../../../src/shared/utils/logger.js');
     logger.setLevel('debug');
-    // Removed mock application initialization
-    // app = new Application({ docsRoot: testEnv.docRoot });
   });
 
   afterEach(async () => {
-    // Cleanup test environment
     await cleanupTestEnv(testEnv);
   });
 
@@ -45,15 +34,14 @@ describe('ContextController Integration Tests', () => {
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.data?.rules).toBeDefined();
-      expect(result.data?.branchMemory?.['branchContext.json']).toBeDefined();
-      // 自動初期化では4つのコアファイルが作成されるはず
-      expect(Object.keys(result.data?.branchMemory || {}).length).toBe(4);
+      expect(result.data?.branchMemory?.coreFiles?.['branchContext.json']).toBeDefined();
+      expect(result.data?.branchMemory?.availableFiles).toHaveLength(4);
       expect(result.data?.globalMemory).toBeDefined();
     });
 
     it('正常系: ブランチとグローバルの両方のメモリバンクからコンテキストを読み取れること', async () => {
       const { toSafeBranchName } = await import('../../../src/shared/utils/branchNameUtils.js');
-      await loadBranchFixture(path.join(testEnv.branchMemoryPath, toSafeBranchName(TEST_BRANCH)), 'basic'); // safeBranchName を使用
+      await loadBranchFixture(path.join(testEnv.branchMemoryPath, toSafeBranchName(TEST_BRANCH)), 'basic');
       await loadGlobalFixture(testEnv.globalMemoryPath, 'minimal');
 
       const controller = await container.get<ContextController>('contextController');
@@ -63,11 +51,11 @@ describe('ContextController Integration Tests', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(Object.keys(result.data?.branchMemory || {}).length).toBeGreaterThan(0);
-      expect(Object.keys(result.data?.globalMemory || {}).length).toBeGreaterThan(0);
+      expect(Object.keys(result.data?.branchMemory?.coreFiles || {}).length).toBeGreaterThan(0);
+      expect(Object.keys(result.data?.globalMemory?.coreFiles || {}).length).toBeGreaterThan(0);
       expect(result.data?.rules).toBeDefined();
-      expect(result.data?.globalMemory?.['core/glossary.json']).toBeDefined();
-      expect(result.data?.branchMemory?.['activeContext.json']).toBeDefined();
+      expect(result.data?.globalMemory?.coreFiles?.['core/glossary.json']).toBeDefined();
+      expect(result.data?.branchMemory?.coreFiles?.['activeContext.json']).toBeDefined();
     });
 
     it('正常系: 存在しないブランチでも自動初期化されたブランチメモリが返されること', async () => {
@@ -78,15 +66,15 @@ describe('ContextController Integration Tests', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data?.branchMemory?.['branchContext.json']).toBeDefined();
-      expect(Object.keys(result.data?.branchMemory || {}).length).toBe(4); // ★ 期待値を4に変更 ★
+      expect(result.data?.branchMemory?.coreFiles?.['branchContext.json']).toBeDefined();
+      expect(result.data?.branchMemory?.availableFiles).toHaveLength(4);
       expect(result.data?.rules).toBeDefined();
       expect(result.data?.globalMemory).toBeDefined();
     });
 
     it('正常系: ファイルが存在するブランチメモリバンクからコンテキストを読み取れること', async () => {
       const { toSafeBranchName } = await import('../../../src/shared/utils/branchNameUtils.js');
-      await loadBranchFixture(path.join(testEnv.branchMemoryPath, toSafeBranchName(TEST_BRANCH)), 'basic'); // safeBranchName を使用
+      await loadBranchFixture(path.join(testEnv.branchMemoryPath, toSafeBranchName(TEST_BRANCH)), 'basic');
 
       const controller = await container.get<ContextController>('contextController');
 
@@ -95,21 +83,21 @@ describe('ContextController Integration Tests', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(Object.keys(result.data?.branchMemory || {}).length).toBeGreaterThan(0);
-      expect(result.data?.branchMemory?.['activeContext.json']).toBeDefined();
-      expect(result.data?.branchMemory?.['branchContext.json']).toBeDefined();
+      expect(Object.keys(result.data?.branchMemory?.coreFiles || {}).length).toBeGreaterThan(0);
+      expect(result.data?.branchMemory?.coreFiles?.['activeContext.json']).toBeDefined();
+      expect(result.data?.branchMemory?.coreFiles?.['branchContext.json']).toBeDefined();
 
-      const branchContext = result.data?.branchMemory?.['branchContext.json']; // Content is already an object
+      const branchContext = result.data?.branchMemory?.coreFiles?.['branchContext.json'];
       expect(branchContext).toBeDefined();
-      expect(typeof branchContext).toBe('object'); // Verify it's an object
-      // Assert properties on the object directly
+      expect(typeof branchContext).toBe('object');
       expect(branchContext).toHaveProperty('schema');
       expect(branchContext).toHaveProperty('documentType');
       expect(branchContext).toHaveProperty('metadata');
       expect(branchContext).toHaveProperty('content');
-      expect((branchContext as any).documentType).toBe('branch_context'); // Assert type for property access
+      expect((branchContext as any).documentType).toBe('branch_context');
     });
   });
+
   describe('readRules', () => {
     it('正常系: 日本語のルールを取得できること', async () => {
       const controller = await container.get<ContextController>('contextController');
@@ -119,8 +107,8 @@ describe('ContextController Integration Tests', () => {
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('ja');
       expect(result.data!.content).toBeDefined();
-      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
-      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
+      expect(typeof result.data!.content).toBe('object');
+      expect(result.data!.content).toHaveProperty('id', 'rules');
       expect(result.error).toBeUndefined();
     });
 
@@ -128,13 +116,12 @@ describe('ContextController Integration Tests', () => {
       const controller = await container.get<ContextController>('contextController');
 
       const result = await controller.readRules('en');
-
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('en');
       expect(result.data!.content).toBeDefined();
-      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
-      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
+      expect(typeof result.data!.content).toBe('object');
+      expect(result.data!.content).toHaveProperty('id', 'rules');
       expect(result.error).toBeUndefined();
     });
 
@@ -142,7 +129,6 @@ describe('ContextController Integration Tests', () => {
       const controller = await container.get<ContextController>('contextController');
 
       const result = await controller.readRules('fr');
-
       expect(result.success).toBe(false);
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
@@ -153,13 +139,12 @@ describe('ContextController Integration Tests', () => {
       const controller = await container.get<ContextController>('contextController');
 
       const result = await controller.readRules('zh');
-
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.data!.language).toBe('zh');
       expect(result.data!.content).toBeDefined();
-      expect(typeof result.data!.content).toBe('object'); // Check if content is an object
-      expect(result.data!.content).toHaveProperty('id', 'rules'); // Check for a known property like 'id'
+      expect(typeof result.data!.content).toBe('object');
+      expect(result.data!.content).toHaveProperty('id', 'rules');
       expect(result.error).toBeUndefined();
     });
   });

--- a/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
+++ b/packages/mcp/tests/integration/usecase/ReadContextUseCase.integration.test.ts
@@ -1,52 +1,39 @@
 /**
  * @jest-environment node
  */
-import { setupTestEnv, cleanupTestEnv, createBranchDir, type TestEnv } from '../helpers/test-env.js'; // 拡張子を .js に変更 (または削除)
+import { setupTestEnv, cleanupTestEnv, createBranchDir, type TestEnv } from '../helpers/test-env.js';
 import { loadBranchFixture, loadGlobalFixture } from '../helpers/fixtures-loader.js';
-import { DIContainer, setupContainer } from '../../../src/main/di/providers.js'; // Import DI container and setup function
-import { ReadContextUseCase } from '../../../src/application/usecases/common/ReadContextUseCase.js'; // Import real UseCase and types
-import { ReadRulesUseCase } from '../../../src/application/usecases/common/ReadRulesUseCase.js'; // Import ReadRulesUseCase for rules check
+import { DIContainer, setupContainer } from '../../../src/main/di/providers.js';
+import { ReadContextUseCase } from '../../../src/application/usecases/common/ReadContextUseCase.js';
+import { ReadRulesUseCase } from '../../../src/application/usecases/common/ReadRulesUseCase.js';
 import type { IBranchMemoryBankRepository } from '../../../src/domain/repositories/IBranchMemoryBankRepository.js';
-import fs from 'fs-extra'; // fs/promises から fs-extra に変更
+import fs from 'fs-extra';
 import { logger } from '../../../src/shared/utils/logger.js';
 import * as path from 'path';
 
 describe('ReadContextUseCase Integration Tests', () => {
   let testEnv: TestEnv;
-  let container: DIContainer; // Use DI container
+  let container: DIContainer;
   let useCase: ReadContextUseCase;
   let readRulesUseCase: ReadRulesUseCase;
   let branchRepo: IBranchMemoryBankRepository;
   const TEST_BRANCH = 'feature/test-branch';
 
   beforeEach(async () => {
-    // Setup test environment
     testEnv = await setupTestEnv();
-
-    // beforeEach でブランチディレクトリを作成しないように変更
-    // (自動初期化のテストのため)
-    // await createBranchDir(testEnv, TEST_BRANCH);
-    // Initialize DI container
     container = await setupContainer({ docsRoot: testEnv.docRoot });
-
-    // Get the use case instances from container
     useCase = await container.get<ReadContextUseCase>('readContextUseCase');
-    readRulesUseCase = await container.get<ReadRulesUseCase>('readRulesUseCase'); // Get ReadRulesUseCase too
+    readRulesUseCase = await container.get<ReadRulesUseCase>('readRulesUseCase');
     branchRepo = await container.get<IBranchMemoryBankRepository>('branchMemoryBankRepository');
-
-    const { logger } = await import('../../../src/shared/utils/logger.js');
     logger.setLevel('debug');
-
   });
 
   afterEach(async () => {
-    // Cleanup test environment
     await cleanupTestEnv(testEnv);
   });
 
   describe('execute', () => {
     it('should get context from an auto-initialized branch and global memory', async () => {
-      // Execute use case
       const result = await useCase.execute({
         branch: TEST_BRANCH,
         language: 'ja'
@@ -54,13 +41,19 @@ describe('ReadContextUseCase Integration Tests', () => {
 
       expect(result).toBeDefined();
       expect(result.branchMemory).toBeDefined();
-      // initialize で複数のコアファイルが作られるはずなので、toEqualではなく length > 0 をチェック
-      expect(Object.keys(result.branchMemory!).length).toBeGreaterThan(0);
-      expect(result.branchMemory!['branchContext.json']).toBeDefined(); // branchContext.json の存在は確認
-      expect(result.branchMemory!['branchContext.json']).toBeDefined();
-      expect(typeof result.globalMemory).toBe('object');
+      expect(result.branchMemory.coreFiles).toBeDefined();
+      expect(result.branchMemory.availableFiles).toBeDefined();
 
-      // Verify rules separately
+      // コアファイルの存在確認
+      expect(result.branchMemory.coreFiles['branchContext.json']).toBeDefined();
+      expect(result.branchMemory.coreFiles['activeContext.json']).toBeDefined();
+      expect(result.branchMemory.coreFiles['progress.json']).toBeDefined();
+      expect(result.branchMemory.coreFiles['systemPatterns.json']).toBeDefined();
+
+      expect(result.globalMemory).toBeDefined();
+      expect(result.globalMemory.coreFiles).toBeDefined();
+      expect(result.globalMemory.availableFiles).toBeDefined();
+
       const rulesResult = await readRulesUseCase.execute('ja');
       expect(rulesResult).toBeDefined();
       expect(rulesResult.language).toBe('ja');
@@ -78,21 +71,24 @@ describe('ReadContextUseCase Integration Tests', () => {
       });
 
       expect(result).toBeDefined();
-
       expect(result.branchMemory).toBeDefined();
-      expect(Object.keys(result.branchMemory!).length).toBeGreaterThan(0);
-      expect(result.branchMemory!['branchContext.json']).toBeDefined();
-      expect(result.branchMemory!['activeContext.json']).toBeDefined();
+      expect(result.branchMemory.coreFiles).toBeDefined();
+      expect(result.branchMemory.availableFiles).toBeDefined();
+
+      // コアファイルの存在確認
+      expect(result.branchMemory.coreFiles['branchContext.json']).toBeDefined();
+      expect(result.branchMemory.coreFiles['activeContext.json']).toBeDefined();
 
       expect(result.globalMemory).toBeDefined();
-      expect(Object.keys(result.globalMemory!).length).toBeGreaterThan(0);
-      expect(result.globalMemory!['core/glossary.json']).toBeDefined();
+      expect(result.globalMemory.coreFiles).toBeDefined();
+      expect(result.globalMemory.availableFiles).toBeDefined();
+      expect(result.globalMemory.coreFiles['core/glossary.json']).toBeDefined();
 
-      const branchContext = result.branchMemory!['branchContext.json']; // Content is already an object
+      const branchContext = result.branchMemory.coreFiles['branchContext.json'];
       expect(branchContext).toBeDefined();
-      expect(typeof branchContext).toBe('object'); // Verify it's an object
+      expect(typeof branchContext).toBe('object');
       expect((branchContext as any).schema).toBe('memory_document_v2');
-      expect((branchContext as any).documentType).toBe('branch_context'); // トップレベルの documentType をチェック
+      expect((branchContext as any).documentType).toBe('branch_context');
     });
 
     it('should get context regardless of language', async () => {
@@ -103,11 +99,10 @@ describe('ReadContextUseCase Integration Tests', () => {
 
       expect(resultEn).toBeDefined();
       expect(resultEn.branchMemory).toBeDefined();
-      // initialize で複数のコアファイルが作られるはずなので、toEqualではなく length > 0 をチェック
-      expect(Object.keys(resultEn.branchMemory!).length).toBeGreaterThan(0);
-      expect(resultEn.branchMemory!['branchContext.json']).toBeDefined(); // branchContext.json の存在は確認
-      expect(resultEn.branchMemory!['branchContext.json']).toBeDefined();
-      expect(typeof resultEn.globalMemory).toBe('object');
+      expect(resultEn.branchMemory.coreFiles).toBeDefined();
+      expect(resultEn.branchMemory.coreFiles['branchContext.json']).toBeDefined();
+      expect(resultEn.branchMemory.coreFiles['activeContext.json']).toBeDefined();
+      expect(resultEn.globalMemory).toBeDefined();
 
       const rulesResultEn = await readRulesUseCase.execute('en');
       expect(rulesResultEn).toBeDefined();
@@ -120,11 +115,10 @@ describe('ReadContextUseCase Integration Tests', () => {
 
       expect(resultZh).toBeDefined();
       expect(resultZh.branchMemory).toBeDefined();
-      // initialize で複数のコアファイルが作られるはずなので、toEqualではなく length > 0 をチェック
-      expect(Object.keys(resultZh.branchMemory!).length).toBeGreaterThan(0);
-      expect(resultZh.branchMemory!['branchContext.json']).toBeDefined(); // branchContext.json の存在は確認
-      expect(resultZh.branchMemory!['branchContext.json']).toBeDefined();
-      expect(typeof resultZh.globalMemory).toBe('object');
+      expect(resultZh.branchMemory.coreFiles).toBeDefined();
+      expect(resultZh.branchMemory.coreFiles['branchContext.json']).toBeDefined();
+      expect(resultZh.branchMemory.coreFiles['activeContext.json']).toBeDefined();
+      expect(resultZh.globalMemory).toBeDefined();
 
       const rulesResultZh = await readRulesUseCase.execute('zh');
       expect(rulesResultZh).toBeDefined();
@@ -134,25 +128,8 @@ describe('ReadContextUseCase Integration Tests', () => {
     it('should get auto-initialized context for a non-existent branch name', async () => {
       const nonExistentBranch = 'feature/non-existent-branch-auto-init';
       const { BranchInfo } = await import('../../../src/domain/entities/BranchInfo.js');
-
-
-      // const { BranchInfo } = await import('../../../src/domain/entities/BranchInfo.js'); // ← ダブりなので削除
       const branchInfo = BranchInfo.create(nonExistentBranch);
-      // useCase.execute に自動初期化を任せるため、ここでの initialize 呼び出しは削除
-      // await branchRepo.initialize(branchInfo);
 
-
-      const { toSafeBranchName } = await import('../../../src/shared/utils/branchNameUtils.js');
-      const branchPath = path.join(testEnv.branchMemoryPath, toSafeBranchName(nonExistentBranch));
-      try {
-        const filesDirectly = await fs.readdir(branchPath);
-        logger.debug('[Mirai Debug] Files immediately after initialize:', { files: filesDirectly.sort(), component: 'ReadContextUseCase.integration.test' });
-      } catch (e) {
-        logger.error('[Mirai Debug] Error reading directory after initialize:', { error: e, component: 'ReadContextUseCase.integration.test' });
-      }
-
-
-      // initialize 完了後に UseCase を実行して結果を取得
       const result = await useCase.execute({
         branch: nonExistentBranch,
         language: 'ja'
@@ -160,7 +137,8 @@ describe('ReadContextUseCase Integration Tests', () => {
 
       expect(result).toBeDefined();
       expect(result.branchMemory).toBeDefined();
-
+      expect(result.branchMemory.coreFiles).toBeDefined();
+      expect(result.branchMemory.availableFiles).toBeDefined();
 
       const expectedCoreFiles = [
         'branchContext.json',
@@ -168,47 +146,38 @@ describe('ReadContextUseCase Integration Tests', () => {
         'activeContext.json',
         'systemPatterns.json'
       ];
-      const actualCoreFiles = Object.keys(result.branchMemory!);
-      expect(actualCoreFiles.sort()).toEqual(expectedCoreFiles.sort()); // 順序無視で比較
 
-      // 各コアファイルの内容を簡単にチェック (存在とJSON形式)
+      // コアファイルの存在確認
       for (const coreFile of expectedCoreFiles) {
-        expect(result.branchMemory![coreFile]).toBeDefined();
-        try {
-          const content = result.branchMemory![coreFile]; // Content is already an object
-          expect(typeof content).toBe('object'); // Verify it's an object
-          expect((content as any).schema).toBe('memory_document_v2'); // スキーマ確認
-          expect((content as any).metadata.path).toBe(coreFile); // パス確認
-        } catch (e) {
-          throw new Error(`Failed to parse JSON for ${coreFile}: ${e}`);
-        }
+        expect(result.branchMemory.coreFiles[coreFile]).toBeDefined();
+        const content = result.branchMemory.coreFiles[coreFile];
+        expect(typeof content).toBe('object');
+        expect((content as any).schema).toBe('memory_document_v2');
+        expect((content as any).metadata.path).toBe(coreFile);
       }
 
-
-      expect(typeof result.globalMemory).toBe('object');
-
+      expect(result.globalMemory).toBeDefined();
       const rulesResult = await readRulesUseCase.execute('ja');
       expect(rulesResult).toBeDefined();
       expect(rulesResult.language).toBe('ja');
     });
 
-    it('should return context with undefined rules for unsupported language', async () => { // テスト名を変更
-      // 準備: ダミーのグローバルファイルを作成
+    it('should return context with undefined rules for unsupported language', async () => {
       const dummyGlobalPath = path.join(testEnv.globalMemoryPath, 'dummy-global.json');
       await fs.outputJson(dummyGlobalPath, { dummy: 'data' });
 
-      // 実行: サポートされていない言語コードで ReadContextUseCase を実行
       const result = await useCase.execute({ branch: TEST_BRANCH, language: 'fr' });
 
-      // 検証: rules が undefined であることを確認
       expect(result).toBeDefined();
-      expect(result.rules).toBeUndefined(); // rules が undefined であることを期待
-      // 他のコンテキスト（branchMemory, globalMemory）は取得できているはず
+      expect(result.rules).toBeUndefined();
       expect(result.branchMemory).toBeDefined();
-      expect(typeof result.globalMemory).toBe('object');
-      // 念のため、他のコンテキストが空でないことも確認（必要に応じて）
-      expect(Object.keys(result.branchMemory!).length).toBeGreaterThan(0);
-      expect(result.globalMemory).toEqual({}); // グローバルメモリは空であることを期待
+      expect(result.branchMemory.coreFiles).toBeDefined();
+      expect(result.branchMemory.availableFiles).toBeDefined();
+      expect(Object.keys(result.branchMemory.coreFiles).length).toBeGreaterThan(0);
+      expect(result.globalMemory).toEqual({
+        coreFiles: {},
+        availableFiles: expect.any(Array)
+      });
     });
   });
 });

--- a/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
+++ b/packages/mcp/tests/unit/application/usecases/common/ReadContextUseCase.test.ts
@@ -1,26 +1,21 @@
-import { vi } from 'vitest'; // vi をインポート
-import type { Mock } from 'vitest'; // Mock 型をインポート
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
 import { ReadContextUseCase } from '../../../../../src/application/usecases/common/ReadContextUseCase.js';
 import { IBranchMemoryBankRepository } from '../../../../../src/domain/repositories/IBranchMemoryBankRepository.js';
 import { IGlobalMemoryBankRepository } from '../../../../../src/domain/repositories/IGlobalMemoryBankRepository.js';
-// import { IRulesRepository } from '../../../../../src/domain/repositories/IRulesRepository.js';
-// import { mock } from 'jest-mock-extended'; // jest-mock-extended を削除
 import { BranchInfo } from '../../../../../src/domain/entities/BranchInfo.js';
 import { MemoryDocument } from '../../../../../src/domain/entities/MemoryDocument.js';
 import { DocumentPath } from '../../../../../src/domain/entities/DocumentPath.js';
 import { Tag } from '../../../../../src/domain/entities/Tag.js';
-// import { Rules } from '../../../../../src/domain/entities/Rules.js';
 
 describe('ReadContextUseCase Unit Tests', () => {
   let useCase: ReadContextUseCase;
-  // jest.Mocked を削除し、手動モックの型を指定
   let mockBranchRepo: IBranchMemoryBankRepository;
   let mockGlobalRepo: IGlobalMemoryBankRepository;
-  // let mockRulesRepo: IRulesRepository;
 
   const branchName = 'feature/test-context';
   const branchInfo = BranchInfo.create(branchName);
-  const language = 'ja'; // Required for input, though not directly used in this version of the use case
+  const language = 'ja';
 
   const mockDocument = (path: string, content: object) =>
     MemoryDocument.create({
@@ -34,12 +29,10 @@ describe('ReadContextUseCase Unit Tests', () => {
   const mockActiveContext = mockDocument('activeContext.json', { current_task: 'Test Task' });
   const mockBranchContext = mockDocument('branchContext.json', { description: 'Test Context' });
   const mockSystemPatterns = mockDocument('systemPatterns.json', { patterns: [] });
-  const mockGlobalDocPath = DocumentPath.create('core/config.json'); // Path corrected to be under core/
+  const mockGlobalDocPath = DocumentPath.create('core/config.json');
   const mockGlobalDoc = mockDocument(mockGlobalDocPath.value, { setting: 'global_value' });
-  // const mockRules = new Rules({ general: ['Rule 1'], specific: { 'feature/test-context': ['Specific Rule'] } });
 
   beforeEach(() => {
-    // jest-mock-extended の代わりに vi.fn() で手動モックを作成する
     mockBranchRepo = {
       initialize: vi.fn(),
       exists: vi.fn(),
@@ -65,12 +58,10 @@ describe('ReadContextUseCase Unit Tests', () => {
       saveTagIndex: vi.fn(),
       getTagIndex: vi.fn(),
       findDocumentPathsByTagsUsingIndex: vi.fn(),
-      updateTagsIndex: vi.fn(), // 不足していたメソッドを追加
+      updateTagsIndex: vi.fn(),
     };
-    // mockRulesRepo = { getRules: vi.fn() };
-    useCase = new ReadContextUseCase(mockBranchRepo, mockGlobalRepo); // Corrected to two arguments
+    useCase = new ReadContextUseCase(mockBranchRepo, mockGlobalRepo);
 
-    // Setup default mocks
     (mockBranchRepo.getDocument as Mock).mockImplementation(async (argBranchInfo, argPath) => {
       if (!argBranchInfo.equals(branchInfo)) return null;
       if (argPath.equals(DocumentPath.create('progress.json'))) return mockProgress;
@@ -87,45 +78,48 @@ describe('ReadContextUseCase Unit Tests', () => {
     ]);
     (mockGlobalRepo.listDocuments as Mock).mockResolvedValue([mockGlobalDocPath]);
     (mockGlobalRepo.getDocument as Mock).mockResolvedValue(mockGlobalDoc);
-    // mockRulesRepo.getRules.mockResolvedValue(mockRules);
   });
 
-  it('should return branch and global memory information', async () => { // Test name changed as Rules are not returned
-    // Act
-    const result = await useCase.execute({ branch: branchName, language }); // Removed docs argument
+  it('should return branch and global memory information', async () => {
+    const result = await useCase.execute({ branch: branchName, language });
 
-    // Assert
-    expect(result.rules).toBeUndefined(); // rules should be undefined
-    // Expect parsed objects instead of strings
+    expect(result.rules).toBeUndefined();
     expect(result.branchMemory).toEqual({
-      'progress.json': JSON.parse(mockProgress.content),
-      'activeContext.json': JSON.parse(mockActiveContext.content),
-      'branchContext.json': JSON.parse(mockBranchContext.content),
-      'systemPatterns.json': JSON.parse(mockSystemPatterns.content),
+      coreFiles: {
+        'progress.json': JSON.parse(mockProgress.content),
+        'activeContext.json': JSON.parse(mockActiveContext.content),
+        'branchContext.json': JSON.parse(mockBranchContext.content),
+        'systemPatterns.json': JSON.parse(mockSystemPatterns.content)
+      },
+      availableFiles: [
+        'progress.json',
+        'activeContext.json',
+        'branchContext.json',
+        'systemPatterns.json'
+      ]
     });
     expect(result.globalMemory).toEqual({
-      [mockGlobalDocPath.value]: JSON.parse(mockGlobalDoc.content),
+      coreFiles: {
+        [mockGlobalDocPath.value]: JSON.parse(mockGlobalDoc.content)
+      },
+      availableFiles: [mockGlobalDocPath.value]
     });
 
-    // expect(mockRulesRepo.getRules).toHaveBeenCalledWith(language, docsPath);
     expect(mockBranchRepo.getDocument).toHaveBeenCalledTimes(4);
     expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
-    expect(mockGlobalRepo.getDocument).toHaveBeenCalledWith(mockGlobalDocPath); // Use the corrected path
+    expect(mockGlobalRepo.getDocument).toHaveBeenCalledWith(mockGlobalDocPath);
   });
 
   it('should return empty global memory if no global documents found', async () => {
-    // Arrange
     (mockGlobalRepo.listDocuments as Mock).mockResolvedValue([]);
 
-    // Act
-    const result = await useCase.execute({ branch: branchName, language }); // Removed docs argument
+    const result = await useCase.execute({ branch: branchName, language });
 
-    // Assert
-    expect(result.globalMemory).toEqual({});
+    expect(result.globalMemory).toEqual({
+      coreFiles: {},
+      availableFiles: []
+    });
     expect(mockGlobalRepo.listDocuments).toHaveBeenCalled();
-    expect(mockGlobalRepo.getDocument).not.toHaveBeenCalled(); // getDocument should not be called
+    expect(mockGlobalRepo.getDocument).not.toHaveBeenCalled();
   });
-
-  // TODO: Add tests for missing branch core files (should still return others)
-  // TODO: Add tests for repository errors
 });


### PR DESCRIPTION
This PR optimizes the read_context response handling for large memory banks by:
- Returning only core files as parsed objects
- Providing a list of available files
- Allowing on-demand retrieval of individual files
- Improving performance for large memory banks