### PR TITLE
fix: Force rebuild by removing tsbuildinfo files before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "prepare": "husky",
-    "build": "tsc -b && node scripts/copy-assets.js",
+    "build": "find . -name \"*.tsbuildinfo\" -type f -delete && tsc -b && node scripts/copy-assets.js",
     "build:mcp": "yarn workspace @memory-bank/mcp build",
     "build:schemas": "yarn workspace @memory-bank/schemas build",
     "copy-assets": "node scripts/copy-assets.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,7 +15,7 @@
     "memory-bank-mcp-server": "./dist/server.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p tsconfig.json",
     "clean": "rm -rf dist",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start": "node dist/index.js",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -62,7 +62,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -f tsconfig.tsbuildinfo && tsc -p tsconfig.json",
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
This pull request includes changes to the build scripts in several `package.json` files to ensure that old TypeScript build information files are deleted before building. This helps to prevent potential issues caused by stale build artifacts.

Changes to build scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Modified the `build` script to delete all `.tsbuildinfo` files before running TypeScript compilation and copying assets.
* [`packages/mcp/package.json`](diffhunk://#diff-adc96623016293ce329af7c2c6419b527d44d978a2ba059b926a85678439a3dbL18-R18): Updated the `build` script to remove the `tsconfig.tsbuildinfo` file before running TypeScript compilation.
* [`packages/schemas/package.json`](diffhunk://#diff-fc1395dfcff5256fba2a18d928df53b4d12fc5e31be2b71649785a56a732b256L65-R65): Updated the `build` script to remove the `tsconfig.tsbuildinfo` file before running TypeScript compilation.