### PR TITLE
[Fix] read context option

### DIFF
--- a/docs/global-memory-bank/09-refactoring/typescript-type-fix.json
+++ b/docs/global-memory-bank/09-refactoring/typescript-type-fix.json
@@ -1,0 +1,35 @@
+{
+  "title": "TypeScriptタイプエラー修正 - RFC6902のOperation型",
+  "date": "2025-04-12",
+  "author": "みらい",
+  "metadata": {
+    "tags": ["typescript", "refactoring", "bugfix", "rfc6902"]
+  },
+  "problemDescription": {
+    "summary": "ビルド時に packages/mcp/src/interface/tools/document-tools.ts ファイルでTypeScriptの型エラーが発生していた",
+    "errorMessage": "error TS2345: Argument of type '{ op: unknown; path: unknown; value: unknown; from: unknown; }[]' is not assignable to parameter of type 'readonly Operation[]'.",
+    "rootCause": "RFC6902 (JSON Patch標準) の操作オブジェクトが適切に型付けされていなかった"
+  },
+  "solution": {
+    "approach": "RFC6902標準に従って厳格な型定義を作成",
+    "implementation": {
+      "steps": [
+        "document-tools.tsファイルでJSON Patch操作に使用される型をより厳密に定義",
+        "AddOperation, RemoveOperation, ReplaceOperation, MoveOperation, CopyOperation, TestOperationなどの型を明示的に定義",
+        "これらの型をUnion型としてJsonPatchOperation型を作成",
+        "formattedPatches 変数に明示的に JsonPatchOperation[] 型を指定",
+        "各種操作タイプに応じて適切なプロパティを持つオブジェクトを生成するよう実装",
+        "不要な型定義と未使用のインポートを削除"
+      ],
+      "codeChanges": {
+        "before": "rfc6902Module.applyPatch(patchedContent, formattedPatches as any[]);",
+        "after": "rfc6902Module.applyPatch(patchedContent, formattedPatches);"
+      }
+    },
+    "outcome": "document-tools.ts ファイルの型エラーが解消され、ビルドが進行するようになった"
+  },
+  "notes": {
+    "otherIssues": "routes.ts にも型エラーがあるが、それは別の問題であり、今回の修正の対象外",
+    "bestPractice": "TypeScriptでは型の厳密さが重要であり、特に外部ライブラリとの連携時には注意が必要。anyの使用は最小限にすべき"
+  }
+}

--- a/packages/mcp/src/application/usecases/types.ts
+++ b/packages/mcp/src/application/usecases/types.ts
@@ -10,7 +10,7 @@ export type RulesResult = {
  * Context request type
  */
 export type ContextRequest = {
-  branch: string;
+  branch?: string; // Make branch optional to allow auto-detection
   language: string;
 };
 

--- a/packages/mcp/src/interface/tools/document-tools.ts
+++ b/packages/mcp/src/interface/tools/document-tools.ts
@@ -10,6 +10,9 @@ import { WriteGlobalDocumentUseCase } from '../../application/usecases/global/Wr
 // import { DocumentRepositorySelector } from '../../application/services/DocumentRepositorySelector.js'; // Not used in the current implementation
 import { MCPResponsePresenter } from '../presenters/MCPResponsePresenter.js';
 import { IConfigProvider } from '../../infrastructure/config/interfaces/IConfigProvider.js';
+// These imports are dynamically loaded in the code when needed
+// import path from 'path';
+// import fsExtra from 'fs-extra/esm';
 
 // Global app instance for tool commands
 // This is a simplified approach for tests - in a real environment
@@ -26,10 +29,10 @@ async function getOrCreateApp(docsRoot: string): Promise<Application> {
   if (!globalApp) {
     console.log(`[getOrCreateApp] Creating new Application instance with docsRoot: ${docsRoot}`);
     globalApp = new Application({ docsRoot });
-    
+
     console.log(`[getOrCreateApp] Initializing Application...`);
     await globalApp.initialize();
-    
+
     console.log(`[getOrCreateApp] Setting up container...`);
     container = await setupContainer({ docsRoot });
     console.log(`[getOrCreateApp] Container setup complete`);
@@ -48,37 +51,37 @@ export interface WriteDocumentParams {
    * Scope to write to (either 'branch' or 'global')
    */
   scope: 'branch' | 'global';
-  
+
   /**
    * Branch name (required if scope is 'branch', auto-detected in project mode)
    */
   branch?: string;
-  
+
   /**
    * Document path (e.g., "data/config.json")
    */
   path: string;
-  
+
   /**
    * Document content to write (object or string, mutually exclusive with patches)
    */
   content?: Record<string, unknown> | string;
-  
+
   /**
    * JSON Patch operations (RFC 6902, mutually exclusive with content)
    */
   patches?: Record<string, unknown>[];
-  
+
   /**
    * Tags to assign to the document
    */
   tags?: string[];
-  
+
   /**
    * Path to docs directory
    */
   docs: string;
-  
+
   /**
    * If true, return the full document content in the output (default: false)
    */
@@ -94,17 +97,17 @@ export interface ReadDocumentParams {
    * Scope to read from (either 'branch' or 'global')
    */
   scope: 'branch' | 'global';
-  
+
   /**
    * Branch name (required if scope is 'branch', auto-detected in project mode)
    */
   branch?: string;
-  
+
   /**
    * Document path (e.g., "data/config.json")
    */
   path: string;
-  
+
   /**
    * Path to docs directory
    */
@@ -114,7 +117,7 @@ export interface ReadDocumentParams {
 /**
  * Implementation of write_document tool
  * Unified interface for writing to both branch and global memory banks
- * 
+ *
  * @example
  * // Writing to branch memory bank
  * const result = await write_document({
@@ -125,7 +128,7 @@ export interface ReadDocumentParams {
  *   tags: ['config', 'feature'],
  *   docs: './docs'
  * });
- * 
+ *
  * @example
  * // Writing to global memory bank
  * const result = await write_document({
@@ -135,7 +138,7 @@ export interface ReadDocumentParams {
  *   tags: ['config', 'core'],
  *   docs: './docs'
  * });
- * 
+ *
  * @example
  * // Using JSON patch
  * const result = await write_document({
@@ -148,7 +151,7 @@ export interface ReadDocumentParams {
  */
 export const write_document: Tool<WriteDocumentParams> = async (params: WriteDocumentParams) => {
   const { scope, branch, path, content, patches, tags, returnContent, docs } = params;
-  
+
   console.log(`[write_document] Starting write_document operation:`, {
     scope,
     branch,
@@ -159,13 +162,13 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
     returnContent,
     docs
   });
-  
+
   // Validate scope parameter
   if (scope !== 'branch' && scope !== 'global') {
     console.error(`[write_document] Invalid scope: ${scope}, must be 'branch' or 'global'`);
     throw new Error(`Invalid scope: ${scope}, must be 'branch' or 'global'`);
   }
-  
+
   // Early branch name check for test compatibility - before any async operation
   if (scope === 'branch' && !branch) {
     try {
@@ -173,7 +176,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
       const localContainer = await setupContainer({ docsRoot: docs });
       const configProvider = await localContainer.get('configProvider') as IConfigProvider;
       const config = configProvider.getConfig();
-      
+
       if (!config.isProjectMode) {
         console.log('[write_document] Branch name missing in non-project mode, throwing error immediately');
         // Make sure the error message is exactly what the test expects to find
@@ -191,7 +194,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
       console.warn('[write_document] Error during early branch check:', error);
     }
   }
-  
+
   try {
     console.log(`[write_document] Starting write_document operation:`, {
       scope,
@@ -203,10 +206,10 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
       returnContent,
       docs
     });
-    
+
     // Get the app and container
     await getOrCreateApp(docs);
-    
+
     console.log(`[write_document] Getting dependencies from container...`);
     // Get necessary dependencies from container
     const readBranchUseCase = await container.get('readBranchDocumentUseCase') as ReadBranchDocumentUseCase;
@@ -216,7 +219,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
     // const repoSelector = await container.get('documentRepositorySelector') as DocumentRepositorySelector; // Not used in the current implementation
     const presenter = await container.get('mcpResponsePresenter') as MCPResponsePresenter;
     console.log(`[write_document] Dependencies retrieved successfully`);
-    
+
     // Create document controller with direct dependencies
     console.log(`[write_document] Creating DocumentController...`);
     const configProvider = await container.get('configProvider') as IConfigProvider;
@@ -229,28 +232,28 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
       presenter,
       configProvider
     );
-  
+
     // Create direct file writing to handle test cases properly
     try {
       const fsExtra = await import('fs-extra');
       const docPath = docs;
-      
+
       // Handle global scope first for test setup
       if (scope === 'global') {
         // Create global memory bank directory and file, needed for test
         const globalMemoryPath = `${docPath}/global-memory-bank`;
         await fsExtra.ensureDir(globalMemoryPath);
         console.log(`[write_document] Direct test: Ensured global directory exists: ${globalMemoryPath}`);
-        
+
         // Ensure subdirectories exist for nested paths
         if (path.includes('/')) {
           const pathDir = path.split('/').slice(0, -1).join('/');
           await fsExtra.ensureDir(`${globalMemoryPath}/${pathDir}`);
         }
-        
+
         // Full path for the document
         const fullPath = `${globalMemoryPath}/${path}`;
-        
+
         // Write file based on content type
         if (typeof content === 'string') {
           await fsExtra.writeFile(fullPath, content);
@@ -277,7 +280,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         const BranchInfo = (await import('../../domain/entities/BranchInfo.js')).BranchInfo;
         const safeBranchName = BranchInfo.create(branchNameToUse).safeName;
         const branchMemoryPath = `${docPath}/branch-memory-bank/${safeBranchName}`;
-        
+
         // Make sure branch directory exists
         await fsExtra.ensureDir(branchMemoryPath);
         console.log(`[write_document] Direct test: Ensured branch directory exists: ${branchMemoryPath}`);
@@ -289,7 +292,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
           const pathDir = path.split('/').slice(0, -1).join('/');
           await fsExtra.ensureDir(`${branchMemoryPath}/${pathDir}`);
         }
-        
+
         // Write file based on content type
         if (typeof content === 'string') {
           await fsExtra.writeFile(fullPath, content);
@@ -304,39 +307,74 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
               // Read existing content
               const existingContent = await fsExtra.readFile(fullPath, 'utf-8');
               const jsonContent = JSON.parse(existingContent);
-              
+
               // Apply patches using rfc6902 library (project dependency)
               const rfc6902Module = await import('rfc6902');
-              
+
+              // Define type aliases for RFC6902 operations
+              // RFC6902 operations types (minimally defined based on the standard)
+              type AddOperation = { op: 'add', path: string, value: any };
+              type RemoveOperation = { op: 'remove', path: string };
+              type ReplaceOperation = { op: 'replace', path: string, value: any };
+              type MoveOperation = { op: 'move', path: string, from: string };
+              type CopyOperation = { op: 'copy', path: string, from: string };
+              type TestOperation = { op: 'test', path: string, value: any };
+
+              // Union type of all operations
+              type JsonPatchOperation =
+                | AddOperation
+                | RemoveOperation
+                | ReplaceOperation
+                | MoveOperation
+                | CopyOperation
+                | TestOperation;
+
+              // Operation type is defined above
+
               // Format patches to ensure they match the rfc6902 format
-              const formattedPatches = patches.map(p => {
-                const operation: any = {
-                  op: p.op,
-                  path: p.path
-                };
-                
-                // Add value for operations that need it
-                if (['add', 'replace', 'test'].includes(operation.op)) {
-                  operation.value = p.value;
+              const formattedPatches: JsonPatchOperation[] = patches.map(p => {
+                const op = p.op as string;
+                const path = p.path as string;
+
+                // Create properly typed operation objects based on operation type
+                if (op === 'add' || op === 'replace' || op === 'test') {
+                  return {
+                    op: op as 'add' | 'replace' | 'test',
+                    path,
+                    value: p.value
+                  };
+                } else if (op === 'move' || op === 'copy') {
+                  return {
+                    op: op as 'move' | 'copy',
+                    path,
+                    from: p.from as string
+                  };
+                } else if (op === 'remove') {
+                  return {
+                    op: 'remove' as const,
+                    path
+                  };
+                } else {
+                  // Fallback for any unrecognized operations - shouldn't happen with valid JSON Patch
+                  console.error(`[write_document] Unknown operation type: ${op}`);
+                  // Return a minimal valid operation to prevent crashes
+                  return {
+                    op: 'test' as const,
+                    path,
+                    value: null
+                  };
                 }
-                
-                // Add from for operations that need it
-                if (['move', 'copy'].includes(operation.op)) {
-                  operation.from = p.from;
-                }
-                
-                return operation;
               });
-              
+
               // Clone the content and apply patches
               const patchedContent = JSON.parse(JSON.stringify(jsonContent));
               rfc6902Module.applyPatch(patchedContent, formattedPatches);
-              
+
               // Update metadata tags if original tags exist and params.tags is provided
               if (patchedContent.metadata && params.tags) {
                 patchedContent.metadata.tags = params.tags;
               }
-              
+
               // Write back patched content
               await fsExtra.writeFile(fullPath, JSON.stringify(patchedContent, null, 2));
               console.log(`[write_document] Direct test: Applied patches to file: ${fullPath}`);
@@ -349,9 +387,9 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
     } catch (err) {
       console.error('[write_document] Error in direct test file writing:', err);
     }
-    
+
     // NOTE: Early branch name check is now done at the top of the function
-    
+
     // Call the appropriate controller method based on the scope
     console.log(`[write_document] Calling documentController.writeDocument...`);
     try {
@@ -364,7 +402,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         tags,
         returnContent
       });
-      
+
       // Log the result from the controller
       console.log(`[write_document] DocumentController result:`, {
         success: result.success,
@@ -372,31 +410,31 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         dataContent: result.success && result.data?.content ? typeof result.data.content : 'undefined',
         dataTags: result.success && result.data?.tags ? result.data.tags.join(',') : 'undefined'
       });
-      
+
       // Transform the response to match what E2E tests expect
       if (result.success && result.data) {
       // Log the actual structure of the result data for debugging
       console.log(`[write_document] Raw result.data structure:`, JSON.stringify(result.data, null, 2));
-      
+
       // Extract data from the result
       let finalResult;
-      
+
       // Check if the result has a document property structure
       if (result.data.document) {
         console.log(`[write_document] Result has document property structure, extracting directly`);
         // The document property contains the actual data structure we want to return
-        
+
         // Check if the content is nested in another level
         let content = result.data.document.content;
         // Try to use original tags from params, or extract from response
         let tags = params.tags || result.data.document.tags || [];
-        
+
         // Specifically for memory documents, extract tags from metadata if available
         if (content && content.metadata && Array.isArray(content.metadata.tags) && content.metadata.tags.length > 0) {
           console.log(`[write_document] Extracting tags from content.metadata`, content.metadata.tags);
           tags = content.metadata.tags;
         }
-        
+
         // Make sure the file exists for tests - テストの為にファイルを直接作っちゃう！
         try {
           const fsExtra = await import('fs-extra');
@@ -417,14 +455,14 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
             const BranchInfo = (await import('../../domain/entities/BranchInfo.js')).BranchInfo;
             const safeBranchName = BranchInfo.create(branchNameToUse).safeName;
             const filePath = `${docPath}/branch-memory-bank/${safeBranchName}/${path}`;
-            
+
             // Ensure parent directory exists - 親ディレクトリも確実に作成！
             const pathParts = path.split('/');
             if (pathParts.length > 1) {
               const dirPath = `${docPath}/branch-memory-bank/${safeBranchName}/${pathParts.slice(0, -1).join('/')}`;
               await fsExtra.ensureDir(dirPath); // fs-extraのensureDirを使って確実に作成
             }
-            
+
             // Always create the file for tests - テスト用に常にファイルを作成
             if (typeof content === 'string') {
               await fsExtra.writeFile(filePath, content);
@@ -442,14 +480,14 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
           } else if (scope === 'global') {
             // Handle global scope
             const filePath = `${docPath}/global-memory-bank/${path}`;
-            
+
             // Ensure parent directory exists
             const pathParts = path.split('/');
             if (pathParts.length > 1) {
               const dirPath = `${docPath}/global-memory-bank/${pathParts.slice(0, -1).join('/')}`;
               await fsExtra.ensureDir(dirPath);
             }
-            
+
             // Write file content
             if (typeof content === 'string') {
               await fsExtra.writeFile(filePath, content);
@@ -462,7 +500,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         } catch (err) {
           console.error('[write_document] Error ensuring file exists:', err);
         }
-        
+
         finalResult = {
           success: true,
           data: {
@@ -478,7 +516,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         let content = result.data.content;
         // Default to the original requested tags when possible
         let tags = params.tags || [];
-        
+
         // Try to extract tags from various possible locations
         if (!tags.length && Array.isArray(result.data.tags)) {
           tags = result.data.tags;
@@ -487,10 +525,10 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         } else if (!tags.length && content && content.metadata && Array.isArray(content.metadata.tags)) {
           tags = content.metadata.tags;
         }
-        
-        const lastModified = result.data.lastModified || 
+
+        const lastModified = result.data.lastModified ||
           (result.data.metadata ? result.data.metadata.lastModified : new Date().toISOString());
-        
+
         finalResult = {
           success: true,
           data: {
@@ -501,7 +539,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
           }
         };
       }
-      
+
       // Debugging the final result structure
       console.log(`[write_document] Final result structure:`, {
         success: finalResult.success,
@@ -512,20 +550,20 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
         tagCount: Array.isArray(finalResult.data.tags) ? finalResult.data.tags.length : 0,
         hasLastModified: !!finalResult.data.lastModified
       });
-      
+
       const response = finalResult;
-      
+
       console.log(`[write_document] Response structure:`, {
         hasContent: !!response.data.content,
         contentType: typeof response.data.content,
         tagsExist: Array.isArray(response.data.tags),
         tagCount: Array.isArray(response.data.tags) ? response.data.tags.length : 0
       });
-      
+
       console.log(`[write_document] Returning successful response`);
       return response;
     }
-    
+
     // If we get here, it means the result wasn't returned in the try block
     // which normally shouldn't happen, but we'll handle it gracefully
     console.log(`[write_document] Result was not properly processed, returning error`);
@@ -548,7 +586,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
 /**
  * Implementation of read_document tool
  * Unified interface for reading from both branch and global memory banks
- * 
+ *
  * @example
  * // Reading from branch memory bank
  * const result = await read_document({
@@ -557,7 +595,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
  *   path: 'data/config.json',
  *   docs: './docs'
  * });
- * 
+ *
  * @example
  * // Reading from global memory bank
  * const result = await read_document({
@@ -565,7 +603,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
  *   path: 'core/config.json',
  *   docs: './docs'
  * });
- * 
+ *
  * @example
  * // Auto-detecting branch name in project mode
  * const result = await read_document({
@@ -577,7 +615,7 @@ export const write_document: Tool<WriteDocumentParams> = async (params: WriteDoc
  */
 export const read_document: Tool<ReadDocumentParams> = async (params) => {
   const { scope, branch, path, docs } = params;
-  
+
   try {
     console.log(`[read_document] Starting read_document operation:`, {
       scope,
@@ -585,13 +623,13 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
       path,
       docs
     });
-    
+
     // Validate scope parameter
     if (scope !== 'branch' && scope !== 'global') {
       console.error(`[read_document] Invalid scope: ${scope}, must be 'branch' or 'global'`);
       throw new Error(`Invalid scope: ${scope}, must be 'branch' or 'global'`);
     }
-    
+
     // Early branch name check for test compatibility - before any async operation
     if (scope === 'branch' && !branch) {
       try {
@@ -599,7 +637,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         const localContainer = await setupContainer({ docsRoot: docs });
         const configProvider = await localContainer.get('configProvider') as IConfigProvider;
         const config = configProvider.getConfig();
-        
+
         if (!config.isProjectMode) {
           console.log('[read_document] Branch name missing in non-project mode, throwing error immediately');
           // Make sure the error message is exactly what the test expects to find
@@ -617,10 +655,10 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         console.warn('[read_document] Error during early branch check:', error);
       }
     }
-    
+
     // Get the app and container
     await getOrCreateApp(docs);
-    
+
     console.log(`[read_document] Getting dependencies from container...`);
     // Get necessary dependencies from container
     const readBranchUseCase = await container.get('readBranchDocumentUseCase') as ReadBranchDocumentUseCase;
@@ -630,7 +668,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
     // const repoSelector = await container.get('documentRepositorySelector') as DocumentRepositorySelector; // Not used in the current implementation
     const presenter = await container.get('mcpResponsePresenter') as MCPResponsePresenter;
     console.log(`[read_document] Dependencies retrieved successfully`);
-    
+
     // Create document controller with direct dependencies
     console.log(`[read_document] Creating DocumentController...`);
     const configProvider = await container.get('configProvider') as IConfigProvider;
@@ -643,25 +681,25 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
       presenter,
       configProvider
     );
-  
+
     // Ensure directories exist for both global and branch paths when reading
     // This helps with tests by ensuring the directory structure exists
     try {
       const fs = await import('fs/promises');
-      
+
       if (scope === 'global' && path.includes('/')) {
         const docPath = docs;
         const globalMemoryPath = `${docPath}/global-memory-bank`;
-        
+
         // Extract directory part from path
         const pathParts = path.split('/');
         const dirParts = pathParts.slice(0, -1); // All except the last part (filename)
-        
+
         if (dirParts.length > 0) {
           // Construct the absolute directory path
           const dirPath = `${globalMemoryPath}/${dirParts.join('/')}`;
           console.log(`[read_document] Checking if global directory exists: ${dirPath}`);
-          
+
           // Use fs promises to check if the directory exists
           try {
             try {
@@ -678,7 +716,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         }
       } else if (scope === 'branch') {
         const docPath = docs;
-        
+
         // Get branch name either from parameters or via auto-detection
         let branchNameToUse = branch;
         if (!branchNameToUse) {
@@ -688,17 +726,17 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
           branchNameToUse = await gitService.getCurrentBranchName();
           console.log(`[read_document] Auto-detected branch name: ${branchNameToUse}`);
         }
-        
+
         // 念のため未定義でないことを確認
         if (!branchNameToUse) {
           throw new Error('Branch name is required but could not be determined automatically');
         }
-        
+
         // Get safe branch name
         const BranchInfo = (await import('../../domain/entities/BranchInfo.js')).BranchInfo;
         const safeBranchName = BranchInfo.create(branchNameToUse).safeName;
         const branchMemoryPath = `${docPath}/branch-memory-bank/${safeBranchName}`;
-        
+
         // Create branch directory if it doesn't exist
         try {
           await fs.mkdir(branchMemoryPath, { recursive: true });
@@ -706,16 +744,16 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         } catch (branchDirError) {
           console.error(`[read_document] Failed to create branch directory: ${branchDirError}`);
         }
-        
+
         // Extract directory part from path
         const pathParts = path.split('/');
         const dirParts = pathParts.slice(0, -1); // All except the last part (filename)
-        
+
         if (dirParts.length > 0) {
           // Construct the absolute directory path
           const dirPath = `${branchMemoryPath}/${dirParts.join('/')}`;
           console.log(`[read_document] Checking if branch subdirectory exists: ${dirPath}`);
-          
+
           try {
             try {
               await fs.access(dirPath);
@@ -733,7 +771,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
     } catch (error) {
       console.error('[read_document] Error ensuring directories exist:', error);
     }
-    
+
     // Special handling for invalid-json.json test case
     if (path.endsWith('invalid-json.json')) {
       console.log(`[read_document] Detected potential invalid-json.json test case, checking file...`);
@@ -753,13 +791,13 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         } else {
           filePath = `${docs}/global-memory-bank/${path}`;
         }
-        
+
         console.log(`[read_document] Checking for invalid JSON file at: ${filePath}`);
         if (await fsExtra.pathExists(filePath)) {
           console.log(`[read_document] Found invalid-json.json file, reading content directly`);
           const content = await fsExtra.readFile(filePath, 'utf8');
           console.log(`[read_document] Read content: ${content}`);
-          
+
           if (content.startsWith('{this is not valid JSON')) {
             console.log('[read_document] Confirmed invalid JSON content, returning success with raw content');
             return {
@@ -778,7 +816,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         // Continue with normal flow if the special case handling fails
       }
     }
-    
+
     // Call the appropriate controller method based on the scope
     console.log(`[read_document] Calling documentController.readDocument...`);
     const result = await documentController.readDocument({
@@ -786,7 +824,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
       branchName: branch,
       path
     });
-    
+
     // Log the result from the controller
     console.log(`[read_document] DocumentController result:`, {
       success: result.success,
@@ -794,24 +832,24 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
       dataContent: result.success && result.data?.content ? typeof result.data.content : 'undefined',
       dataTags: result.success && result.data?.tags ? result.data.tags.join(',') : 'undefined'
     });
-    
+
     // Transform the response to match what E2E tests expect
     if (result.success && result.data) {
       // Log the actual structure of the result data for debugging
       console.log(`[read_document] Raw result.data structure:`, JSON.stringify(result.data, null, 2));
-      
+
       // Extract data from the result
       let finalResult;
-      
+
       // Check if the result has a document property structure
       if (result.data.document) {
         console.log(`[read_document] Result has document property structure, extracting directly`);
         // The document property contains the actual data structure we want to return
-        
+
         // Check if the content is nested in another level
         let content = result.data.document.content;
         let tags = result.data.document.tags || [];
-        
+
         // Handle invalid JSON case gracefully - always return success for this specific test case
         if (path.endsWith('invalid-json.json') && typeof content === 'string' && content.startsWith('{this is not valid JSON')) {
           console.log('[read_document] Detected invalid JSON file, handling gracefully');
@@ -826,13 +864,13 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
           };
           return finalResult;
         }
-        
+
         // Specifically for memory documents, extract tags from metadata if available
         if (content && content.metadata && Array.isArray(content.metadata.tags) && content.metadata.tags.length > 0) {
           console.log(`[read_document] Extracting tags from content.metadata`, content.metadata.tags);
           tags = content.metadata.tags;
         }
-        
+
         finalResult = {
           success: true,
           data: {
@@ -847,7 +885,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         // Fallback for other result structures
         let content = result.data.content;
         let tags = [];
-        
+
         // Try to extract tags from various possible locations
         if (Array.isArray(result.data.tags)) {
           tags = result.data.tags;
@@ -856,10 +894,10 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         } else if (content && content.metadata && Array.isArray(content.metadata.tags)) {
           tags = content.metadata.tags;
         }
-        
-        const lastModified = result.data.lastModified || 
+
+        const lastModified = result.data.lastModified ||
           (result.data.metadata ? result.data.metadata.lastModified : new Date().toISOString());
-        
+
         finalResult = {
           success: true,
           data: {
@@ -870,7 +908,7 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
           }
         };
       }
-      
+
       // Debugging the final result structure
       console.log(`[read_document] Final result structure:`, {
         success: finalResult.success,
@@ -881,9 +919,9 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         tagCount: Array.isArray(finalResult.data.tags) ? finalResult.data.tags.length : 0,
         hasLastModified: !!finalResult.data.lastModified
       });
-      
+
       const response = finalResult;
-      
+
       console.log(`[read_document] Response content type:`, typeof response.data.content);
       console.log(`[read_document] Response structure:`, {
         hasContent: !!response.data.content,
@@ -891,11 +929,11 @@ export const read_document: Tool<ReadDocumentParams> = async (params) => {
         tagsExist: Array.isArray(response.data.tags),
         tagCount: Array.isArray(response.data.tags) ? response.data.tags.length : 0
       });
-      
+
       console.log(`[read_document] Returning successful response`);
       return response;
     }
-    
+
     console.log(`[read_document] Returning original result:`, {
       success: result.success,
       hasError: !result.success,

--- a/packages/mcp/src/main/Application.ts
+++ b/packages/mcp/src/main/Application.ts
@@ -26,6 +26,14 @@ export class Application {
   private branchController?: IBranchController;
   private contextController?: IContextController;
 
+  // Expose configProvider for tools to check project mode
+  public get configProvider() {
+    if (!this.container) {
+      throw new Error('Application not initialized. Call initialize() first.');
+    }
+    return this.container.get('configProvider');
+  }
+
   /**
    * Constructor
    * @param options Minimal application options

--- a/packages/mcp/src/main/routes.ts
+++ b/packages/mcp/src/main/routes.ts
@@ -4,77 +4,113 @@ import { Application } from './Application.js';
 import { logger } from '../shared/utils/logger.js';
 import { Language, isValidLanguage } from '@memory-bank/schemas';
 import type { CliOptions } from '../infrastructure/config/WorkspaceConfig.js'; // Use relative path
+import type { IConfigProvider } from '../infrastructure/config/interfaces/IConfigProvider.js';
+import type { IConfigProvider } from '@/infrastructure/config/index.js';
 
-// Simulated tool definitions
-const AVAILABLE_TOOLS = [
-  {
-    name: 'read_branch_memory_bank',
-    description: 'Read a document from the current branch\'s memory bank',
-    parameters: {
-      type: 'object',
-      properties: {
-        path: { type: 'string' },
-        branch: { type: 'string' },
-        docs: { type: 'string' }
-      },
-      required: ['path', 'branch', 'docs']
+/**
+ * Generates tool definitions based on current environment settings
+ *
+ * This function dynamically creates tool definitions for the MCP server,
+ * taking into account environment variables and configuration settings.
+ * It allows hiding parameters that are already defined via CLI options.
+ */
+function generateToolDefinitions(configProvider: IConfigProvider | null = null) {
+  // Determine which parameters should be required vs. optional
+  const isProjectMode = configProvider?.getConfig().isProjectMode || false;
+  const hasDocsPathEnv = !!process.env.MEMORY_BANK_ROOT || !!process.env.DOCS_ROOT;
+  const hasLanguageEnv = !!process.env.LANGUAGE;
+
+  logger.debug(`Generating tool definitions:`, {
+    isProjectMode,
+    hasDocsPathEnv,
+    hasLanguageEnv
+  });
+
+  // Common tool properties
+  const branchRequired = !isProjectMode;
+  const docsRequired = !hasDocsPathEnv;
+  const languageRequired = !hasLanguageEnv;
+
+  // Read Context Tool: Dynamic required parameters
+  const readContextRequired = ['docs', 'language', 'branch'].filter(param => {
+    if (param === 'branch') return branchRequired;
+    if (param === 'docs') return docsRequired;
+    if (param === 'language') return languageRequired;
+    return true;
+  });
+
+  logger.debug(`Read context required parameters:`, readContextRequired);
+
+  return [
+    {
+      name: 'read_branch_memory_bank',
+      description: 'Read a document from the current branch\'s memory bank',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          branch: { type: 'string' },
+          docs: { type: 'string' }
+        },
+        required: ['path', ...(branchRequired ? ['branch'] : []), ...(docsRequired ? ['docs'] : [])]
+      }
+    },
+    {
+      name: 'write_branch_memory_bank',
+      description: 'Write a document to the current branch\'s memory bank',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          content: { type: 'string' },
+          patches: { type: 'array' },
+          branch: { type: 'string' },
+          docs: { type: 'string' }
+        },
+        required: ['path', ...(branchRequired ? ['branch'] : []), ...(docsRequired ? ['docs'] : [])]
+      }
+    },
+    {
+      name: 'read_global_memory_bank',
+      description: 'Read a document from the global memory bank',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          docs: { type: 'string' }
+        },
+        required: ['path', ...(docsRequired ? ['docs'] : [])]
+      }
+    },
+    {
+      name: 'write_global_memory_bank',
+      description: 'Write a document to the global memory bank',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          content: { type: 'string' },
+          patches: { type: 'array' },
+          docs: { type: 'string' }
+        },
+        required: [...(docsRequired ? ['docs'] : [])]
+      }
+    },
+    {
+      name: 'read_context',
+      description: 'Read all context information (rules, branch memory bank, global memory bank) at once',
+      parameters: {
+        type: 'object',
+        properties: {
+          branch: { type: 'string' },
+          docs: { type: 'string' },
+          language: { type: 'string', enum: ['en', 'ja', 'zh'] }
+        },
+        required: readContextRequired
+      }
     }
-  },
-  {
-    name: 'write_branch_memory_bank',
-    description: 'Write a document to the current branch\'s memory bank',
-    parameters: {
-      type: 'object',
-      properties: {
-        path: { type: 'string' },
-        content: { type: 'string' },
-        patches: { type: 'array' },
-        branch: { type: 'string' },
-        docs: { type: 'string' }
-      },
-      required: ['path', 'branch', 'docs']
-    }
-  },
-  {
-    name: 'read_global_memory_bank',
-    description: 'Read a document from the global memory bank',
-    parameters: {
-      type: 'object',
-      properties: {
-        path: { type: 'string' },
-        docs: { type: 'string' }
-      },
-      required: ['path', 'docs']
-    }
-  },
-  {
-    name: 'write_global_memory_bank',
-    description: 'Write a document to the global memory bank',
-    parameters: {
-      type: 'object',
-      properties: {
-        path: { type: 'string' },
-        content: { type: 'string' },
-        patches: { type: 'array' },
-        docs: { type: 'string' }
-      },
-      required: ['docs']
-    }
-  },
-  {
-    name: 'read_context',
-    description: 'Read all context information (rules, branch memory bank, global memory bank) at once',
-    parameters: {
-      type: 'object',
-      properties: {
-        branch: { type: 'string' },
-        docs: { type: 'string' },
-        language: { type: 'string', enum: ['en', 'ja', 'zh'] }
-      },
-      required: ['branch', 'docs', 'language']
-    }
-  }
-];
+  ];
+}
 
 export function resolveDocsRoot(toolDocs?: string, defaultDocsPath = './docs') {
   if (toolDocs) {
@@ -115,9 +151,15 @@ function getMergedApplicationOptions(appInstance: Application | null, docs?: str
  * @param app Application instance
  */
 export function setupRoutes(server: Server, app: Application | null = null): void {
+  // Get config provider from the app if available
+  const configProvider = app ? app.configProvider : null;
+
+  // Generate tool definitions dynamically based on environment
+  const dynamicTools = generateToolDefinitions(configProvider);
+
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      tools: AVAILABLE_TOOLS,
+      tools: dynamicTools,
     };
   });
 
@@ -309,16 +351,32 @@ export function setupRoutes(server: Server, app: Application | null = null): voi
       }
 
       case 'read_context': {
-        const branch = (params.branch as string | undefined) || '_current_';
-        const language = (params.language as string) || 'ja';
-        const docs = params.docs as string | undefined;
+        // Get parameters from request or use environment/config defaults if available
+        const providedBranch = params.branch as string | undefined;
+        const providedLanguage = params.language as string | undefined;
+        const providedDocs = params.docs as string | undefined;
 
-        const docsRoot = docs || resolveDocsRoot();
-        logger.info(`Reading context (branch: ${branch || 'none'}, language: ${language}, docsRoot: ${docsRoot})`);
+        // Resolve final values with fallbacks
+        const docsRoot = providedDocs || resolveDocsRoot();
+        const language = providedLanguage ||
+                        process.env.LANGUAGE ||
+                        (app ? app.options.language : 'ja');
 
-        if (!branch) {
-          throw new Error('Branch name is required for read_context');
+        // Branch can be auto-detected in project mode
+        const isProjectMode = app?.configProvider.getConfig().isProjectMode || false;
+        let branch = providedBranch;
+
+        logger.info(`Reading context (providedBranch: ${providedBranch || 'none'}, providedLanguage: ${providedLanguage || 'none'}, docsRoot: ${docsRoot}, isProjectMode: ${isProjectMode})`);
+
+        // Check if we need branch auto-detection
+        if (!branch && isProjectMode) {
+          logger.debug('Branch not provided but in project mode, will use auto-detection');
+          // Actual auto-detection happens in the UseCase, no need to do it here
+        } else if (!branch && !isProjectMode) {
+          // Only throw if branch is truly required (not in project mode and not provided)
+          throw new Error('Branch name is required for read_context when not in project mode');
         }
+
         if (!app) {
           throw new Error('Application not initialized');
         }
@@ -327,15 +385,17 @@ export function setupRoutes(server: Server, app: Application | null = null): voi
           logger.debug('Requesting context from ContextController');
 
           let contextApp = app;
-          if (docs) {
+          if (providedDocs) {
             logger.debug(`Creating new application instance with docsRoot: ${docsRoot}`);
             const appOptions = getMergedApplicationOptions(app, docsRoot, isValidLanguage(language) ? language : 'en');
             logger.debug(`Using merged application options: ${JSON.stringify(appOptions)}`);
             // Normally create a new app instance here, using existing for simplicity
           }
 
+          // Pass parameters to readContext, even if some are undefined
+          // The ContextController and ReadContextUseCase will handle auto-detection
           const response = await contextApp.getContextController().readContext({
-            branch,
+            branch,  // This might be undefined, which is OK for auto-detection
             language
           });
 

--- a/packages/mcp/src/main/routes.ts
+++ b/packages/mcp/src/main/routes.ts
@@ -5,7 +5,6 @@ import { logger } from '../shared/utils/logger.js';
 import { Language, isValidLanguage } from '@memory-bank/schemas';
 import type { CliOptions } from '../infrastructure/config/WorkspaceConfig.js'; // Use relative path
 import type { IConfigProvider } from '../infrastructure/config/interfaces/IConfigProvider.js';
-import type { IConfigProvider } from '@/infrastructure/config/index.js';
 
 /**
  * Generates tool definitions based on current environment settings
@@ -387,7 +386,7 @@ export function setupRoutes(server: Server, app: Application | null = null): voi
           let contextApp = app;
           if (providedDocs) {
             logger.debug(`Creating new application instance with docsRoot: ${docsRoot}`);
-            const appOptions = getMergedApplicationOptions(app, docsRoot, isValidLanguage(language) ? language : 'en');
+            const appOptions = getMergedApplicationOptions(app, docsRoot, isValidLanguage(language as Language) ? (language as Language) : 'en');
             logger.debug(`Using merged application options: ${JSON.stringify(appOptions)}`);
             // Normally create a new app instance here, using existing for simplicity
           }
@@ -396,7 +395,7 @@ export function setupRoutes(server: Server, app: Application | null = null): voi
           // The ContextController and ReadContextUseCase will handle auto-detection
           const response = await contextApp.getContextController().readContext({
             branch,  // This might be undefined, which is OK for auto-detection
-            language
+            language: language || 'en' // Provide default language if undefined
           });
 
           if (!response.success) {

--- a/packages/mcp/tests/e2e/context.mcp-test.ts
+++ b/packages/mcp/tests/e2e/context.mcp-test.ts
@@ -73,7 +73,7 @@ describe('MCP E2E Context Tests (using mcp-test)', () => {
   });
 
   describe('read_context command', () => {
-    it('should read context from branch', async () => {
+    it('should read context from branch when branch is specified', async () => {
       // コンテキスト読み取りテスト
       const readResult = await callToolWithLegacySupport(client, 'read_context', {
         branch: testBranch,
@@ -102,6 +102,58 @@ describe('MCP E2E Context Tests (using mcp-test)', () => {
       }
     });
 
+    // プロジェクトモードでブランチが省略できることをテスト
+    it('should auto-detect branch when in project mode and branch is omitted', async () => {
+      // プロジェクトモードをシミュレート
+      process.env.MEMORY_BANK_PROJECT_MODE = 'true';
+
+      try {
+        // DIコンテナからgitServiceを直接取得してモック
+        const { setupContainer } = await import('../../src/main/di/providers.js');
+        const container = await setupContainer({ docsRoot: app.options.docsRoot });
+        const gitService = await container.get('gitService');
+
+        // オリジナルの実装を保存
+        const originalGetCurrentBranchName = gitService.getCurrentBranchName;
+
+        try {
+          // テスト用のブランチ名を返すように上書き
+          gitService.getCurrentBranchName = async () => testBranch;
+
+          // ブランチ名を省略してコンテキスト読み取りテスト
+          const readResult = await callToolWithLegacySupport(client, 'read_context', {
+            // branch パラメータは省略
+            language: 'en',
+            docs: app.options.docsRoot
+          }) as MockToolResponse;
+
+          expect(readResult).toBeDefined();
+          expect(readResult.success).toBe(true);
+
+          if (readResult.success && readResult.data) {
+            // コンテキストの内容を確認
+            const contextData = readResult.data;
+
+            // ブランチ情報があること (自動検出されたもの)
+            expect(contextData.branch).toBeDefined();
+            expect(contextData.branch.name).toBe(testBranch);
+
+            // アクティブタスク情報があること
+            expect(contextData.activeTasks).toBeDefined();
+            expect(Array.isArray(contextData.activeTasks)).toBe(true);
+          } else {
+            throw new Error('Failed to read context with auto-detected branch');
+          }
+        } finally {
+          // テスト後にgitServiceの実装を元に戻す
+          gitService.getCurrentBranchName = originalGetCurrentBranchName;
+        }
+      } finally {
+        // テスト後に環境を元に戻す
+        delete process.env.MEMORY_BANK_PROJECT_MODE;
+      }
+    });
+
     it('should read context with specific language parameter', async () => {
       // 日本語コンテキスト読み取りテスト
       const readResult = await callToolWithLegacySupport(client, 'read_context', {
@@ -120,6 +172,73 @@ describe('MCP E2E Context Tests (using mcp-test)', () => {
         expect(contextData.branch.name).toBe(testBranch);
       } else {
         throw new Error('Failed to read context with language parameter');
+      }
+    });
+
+    // 環境変数から language を取得するテスト
+    it('should use language from environment when language parameter is omitted', async () => {
+      // 環境変数に言語を設定
+      process.env.LANGUAGE = 'ja';
+
+      try {
+        // language パラメータを省略してコンテキスト読み取りテスト
+        const readResult = await callToolWithLegacySupport(client, 'read_context', {
+          branch: testBranch,
+          // language パラメータは省略
+          docs: app.options.docsRoot
+        }) as MockToolResponse;
+
+        expect(readResult).toBeDefined();
+        expect(readResult.success).toBe(true);
+
+        if (readResult.success && readResult.data) {
+          // コンテキストの内容を確認
+          const contextData = readResult.data;
+          // データが正しく取得できていることを確認
+          expect(contextData.branch).toBeDefined();
+          expect(contextData.branch.name).toBe(testBranch);
+        } else {
+          throw new Error('Failed to read context with language from environment');
+        }
+      } finally {
+        // テスト後に環境を元に戻す
+        delete process.env.LANGUAGE;
+      }
+    });
+
+    // docs パラメータが省略できるテスト
+    it('should use docs path from environment when docs parameter is omitted', async () => {
+      // 環境変数に docs パスを設定
+      const originalDocsRoot = process.env.DOCS_ROOT;
+      process.env.DOCS_ROOT = app.options.docsRoot;
+
+      try {
+        // docs パラメータを省略してコンテキスト読み取りテスト
+        const readResult = await callToolWithLegacySupport(client, 'read_context', {
+          branch: testBranch,
+          language: 'en',
+          // docs パラメータは省略
+        }) as MockToolResponse;
+
+        expect(readResult).toBeDefined();
+        expect(readResult.success).toBe(true);
+
+        if (readResult.success && readResult.data) {
+          // コンテキストの内容を確認
+          const contextData = readResult.data;
+          // データが正しく取得できていることを確認
+          expect(contextData.branch).toBeDefined();
+          expect(contextData.branch.name).toBe(testBranch);
+        } else {
+          throw new Error('Failed to read context with docs from environment');
+        }
+      } finally {
+        // テスト後に環境を元に戻す
+        if (originalDocsRoot) {
+          process.env.DOCS_ROOT = originalDocsRoot;
+        } else {
+          delete process.env.DOCS_ROOT;
+        }
       }
     });
 


### PR DESCRIPTION
This pull request includes several changes to improve TypeScript type definitions, enhance the flexibility of tool definitions, and add new tests for context reading in project mode. The most important changes include the introduction of strict RFC6902 operation types, making the `branch` parameter optional for context requests, dynamically generating tool definitions based on the environment, and adding tests for auto-detection of parameters.

### TypeScript Type Improvements:
* [`packages/mcp/src/interface/tools/document-tools.ts`](diffhunk://#diff-0e0350dbad7691d66ce8bbcdd03929f2abfcd125a16c808cec1c261c7bdf8068L311-L328): Introduced strict RFC6902 operation types and updated the code to use these types, removing the use of `any`.
* [`docs/global-memory-bank/09-refactoring/typescript-type-fix.json`](diffhunk://#diff-339cf99f034b5a98e30b755fb505aeed8c11f4d4d61a22ac32b7ae4a503edf0cR1-R35): Added a detailed JSON file documenting the TypeScript type error fix and the approach taken to resolve it.

### Context Request Enhancements:
* [`packages/mcp/src/application/usecases/types.ts`](diffhunk://#diff-4f4469e95c79026744980799e9a5f9cb9341c6fe0ff0ea6ae94f3bfe0b7a541bL13-R13): Made the `branch` parameter optional in the `ContextRequest` type to allow for auto-detection.

### Dynamic Tool Definitions:
* [`packages/mcp/src/main/routes.ts`](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceR7-R43): Refactored the tool definitions to be generated dynamically based on the current environment and configuration settings, allowing for more flexible and context-aware tool setup. [[1]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceR7-R43) [[2]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL20-R54) [[3]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL35-R69) [[4]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL47-R81) [[5]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL61-R95) [[6]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL74-R112) [[7]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceR153-R161) [[8]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL312-R378) [[9]](diffhunk://#diff-c97721445da4f5e7e14306fd0818ecf14241b1fd29efc26fadebe00d900584ceL330-R398)

### New Tests:
* [`packages/mcp/tests/e2e/context.mcp-test.ts`](diffhunk://#diff-0c756631aaf08863937ed4770c301e28381757a63266d88b742276caf15da5a8L76-R76): Added new end-to-end tests to verify the auto-detection of the `branch` parameter in project mode, the use of the `language` parameter from the environment, and the use of the `docs` parameter from the environment. [[1]](diffhunk://#diff-0c756631aaf08863937ed4770c301e28381757a63266d88b742276caf15da5a8L76-R76) [[2]](diffhunk://#diff-0c756631aaf08863937ed4770c301e28381757a63266d88b742276caf15da5a8R105-R156) [[3]](diffhunk://#diff-0c756631aaf08863937ed4770c301e28381757a63266d88b742276caf15da5a8R178-R244)