### PR TITLE
Refactor server.ts to delegate routing logic to routes.ts

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,20 +5,14 @@
 // import { fileURLToPath } from 'url'; // 未使用のためコメントアウト
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-// アプリケーションのインポート (パスを src からの相対パスに修正)
+// アプリケーションのインポート
 import { createApplication, Application } from './main/index.js';
-import { logger } from './shared/utils/logger.js'; // logger もインポート
-import { getToolDefinitions } from './tools/definitions.js'; // 関数をインポート
-import { Language, isValidLanguage } from '@memory-bank/schemas/v2/i18n-schema'; // Language 型とヘルパーを正しいパスからインポート
-import type { ContextRequest } from './application/usecases/types.js'; // 共通型定義のContextRequestをインポート
-import type { SearchDocumentsByTagsInput } from './application/usecases/common/SearchDocumentsByTagsUseCase.js'; // 正しいパスからインポート
-import type { DocumentDTO } from './application/dtos/DocumentDTO.js'; // DocumentDTO をインポート
-import type { MCPResponse } from './interface/presenters/types/MCPResponse.js'; // MCPResponse をインポート
-// import { applyPatch } from './tools/patch-utils.js'; // 不要なインポートを削除
+import { logger } from './shared/utils/logger.js';
+import { Language, isValidLanguage } from '@memory-bank/schemas/v2/i18n-schema';
+import { setupRoutes } from './main/routes.js'; // routes.ts から setupRoutes 関数をインポート
 
 // Parse command line arguments
 const argv = yargs(hideBin(process.argv))
@@ -65,135 +59,8 @@ const server = new Server(
   }
 );
 
-// Set up tool handlers
-server.setRequestHandler(ListToolsRequestSchema, async () => { // 元のスキーマ指定に戻す
-  const tools = getToolDefinitions(); // 関数を呼び出してツールリストを取得
-  return {
-    tools: tools,
-  };
-});
-
-// Add tool request handler
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  logger.debug('Tool call received:', { name, args });
-
-  if (!app) {
-    logger.error('Application not initialized when tool call received.');
-    throw new Error('Application not initialized');
-  }
-  if (!args || typeof args !== 'object') {
-    logger.error('Invalid arguments:', { name, args });
-    throw new Error(`No arguments provided for tool: ${name}`);
-  }
-  const params = args as Record<string, unknown>;
-  logger.debug('Parsed params:', params);
-
-  try {
-    let response: MCPResponse; // コントローラーからのレスポンスを格納する変数
-
-    // ツール名に応じて適切なコントローラーを呼び出す
-    switch (name) {
-      case 'read_context': {
-        // languageの検証を行い有効なLanguage型に変換
-        const language = params.language as string;
-        if (!isValidLanguage(language)) {
-          logger.error(`Invalid language: ${language}`);
-          throw new Error(`Invalid language: ${language}. Supported languages are: en, ja, zh`);
-        }
-
-        // branchの検証
-        if (!params.branch || typeof params.branch !== 'string' || params.branch.trim() === '') {
-          logger.error(`Missing or invalid branch name: ${params.branch}`);
-          throw new Error('Branch name is required for read_context');
-        }
-
-        // 検証済みの値でContextRequest オブジェクトを作成
-        const contextRequest: ContextRequest = {
-          branch: params.branch as string,
-          language: language as Language, // 検証済みの値なのでLanguage型として安全
-        };
-
-        // 戻り値の型が MCPResponse と互換性を持つように適切な型変換が必要
-        response = await app.getContextController().readContext(contextRequest) as MCPResponse;
-        break;
-      }
-      case 'search_documents_by_tags': {
-         // SearchDocumentsByTagsInput オブジェクトを作成して渡す
-         // branch を branchName に修正
-         const searchInput: SearchDocumentsByTagsInput = {
-           tags: params.tags as string[], // 型を明示的に指定
-           match: params.match as 'and' | 'or' | undefined, // 型を明示的に指定
-           scope: params.scope as 'branch' | 'global' | 'all' | undefined, // 型を明示的に指定
-           branchName: params.branch as string, // 型を明示的に指定
-           docs: argv.docs // Changed from docsRoot
-         };
-         response = await app.getGlobalController().searchDocumentsByTags(searchInput);
-         break;
-      }
-      // 他のツールも同様に修正...
-      default:
-        throw new Error(`Unknown tool: ${name}`);
-    }
-
-    // コントローラーからのレスポンスをMCP形式に変換して返す
-    // (JsonResponsePresenter や MCPResponsePresenter を使うのが理想)
-    // TODO: Refactor response handling using presenters
-    if (response && response.success && response.data !== undefined) { // data の存在もチェック
-       // 成功時のレスポンス形式を調整 (仮)
-       if (typeof response.data === 'string') {
-           return { content: [{ type: 'text', text: response.data }] };
-       } else if (typeof response.data === 'object' && response.data !== null) { // null チェック追加
-           // DocumentDTO など、lastModified を持つ可能性のあるオブジェクト
-           const meta = (response.data as Record<string, unknown>).lastModified ?
-             { lastModified: (response.data as Record<string, unknown>).lastModified }
-             : undefined;
-           // content プロパティがあるか、なければ全体をJSON化
-           let contentText: string;
-           const documentData = response.data as DocumentDTO; // 型アサーション
-
-           // JSON形式のドキュメントの場合はパースを試みる
-           if (documentData && typeof documentData.path === 'string' && documentData.path.endsWith('.json') && typeof documentData.content === 'string') {
-             try {
-               // JSON 文字列をパースしてオブジェクトにする
-               const parsedContent = JSON.parse(documentData.content);
-               // MCPレスポンスとしては整形されたJSON文字列を返す
-               contentText = JSON.stringify(parsedContent, null, 2);
-               logger.debug(`[Server] Parsed JSON content for response: ${documentData.path}`);
-             } catch (e) {
-               logger.warn('[Server] Failed to parse JSON content in response handling, returning raw string.', { path: documentData.path, error: e });
-               contentText = documentData.content; // パース失敗時は元の文字列
-             }
-           } else if (documentData && typeof documentData.content === 'string') {
-             // JSON以外、または content が文字列の場合
-             contentText = documentData.content;
-           } else {
-             // contentがない、または文字列でない場合、全体をJSON化
-             contentText = JSON.stringify(response.data, null, 2);
-           }
-           return { content: [{ type: 'text', text: contentText }], _meta: meta };
-       } else {
-           // 文字列でもオブジェクトでもない成功データ (例: boolean)
-           return { content: [{ type: 'text', text: String(response.data) }] };
-       }
-    } else if (response && response.success && response.data === undefined) {
-        // データなしの成功レスポンス (例: write操作)
-        return { content: [{ type: 'text', text: 'Operation successful' }] };
-    } else if (response && !response.success && response.error) {
-        // エラーレスポンス
-        throw new Error(response.error.message || 'Tool execution failed');
-    } else {
-        // 予期せぬレスポンス
-        logger.warn('Unexpected response from controller:', response);
-        return { content: [{ type: 'text', text: 'Operation completed with unexpected result' }] };
-    }
-
-  } catch (error: unknown) {
-    logger.error(`Error executing tool ${name}:`, error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    throw new Error(`Tool execution failed: ${errorMessage}`);
-  }
-});
+// サーバーの基本設定
+// ここでは、リクエストハンドラの設定は routes.ts に委譲する
 
 // Error handling
 server.onerror = (error) => {
@@ -252,11 +119,15 @@ async function main() {
 
     // Initialize application
     app = await createApplication({
-        docsRoot: argv.docs, // Changed from docsRoot
+        docsRoot: argv.docs,
         verbose: argv.verbose,
-        language: safeLanguage, // 安全な型を渡す
+        language: safeLanguage,
     });
     logger.info('Application initialized successfully');
+
+    // ルーティングの設定をroutes.tsに委譲
+    setupRoutes(server, app);
+    logger.info('MCP Server routes configured');
 
     // Connect the server to the Stdio transport
     await server.connect(new StdioServerTransport());


### PR DESCRIPTION
## Overview
This PR refactors the relationship between `server.ts` and `routes.ts` to establish a clear separation of concerns between them.

### Current Issue
Currently, the routing logic is duplicated between `server.ts` and `routes.ts`, which leads to:
- Code duplication and potential inconsistencies
- Unclear responsibility boundaries
- Maintenance challenges when adding new tools or modifying existing ones

### Changes Made
- Removed duplicate routing logic from `server.ts`
- Delegated all request handling to `setupRoutes` function from `routes.ts`
- Cleaned up imports and improved code organization
- Added explicit setup log for better debugging

### Architectural Benefits
This refactoring creates a clear separation of concerns:
- `server.ts` now focuses on server setup, lifecycle management, and CLI handling
- `routes.ts` now handles all routing, validation, and controller delegation

### Testing
- All tests pass successfully
- Build completes without errors

### Notes for Reviewers
This is a non-functional change that improves code organization without modifying behavior. The main focus was reducing duplication and establishing clear responsibilities between components.

The PR is intentionally small in scope to make review easier and reduce risk.
