### PR TITLE
fix: improve version retrieval and configure git user for tagging

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           # Try to get version from root package.json first
           ROOT_VERSION=$(node -p "try { require('./package.json').version } catch (e) { '' }" || echo "")
-          
+
           # If root version is empty, get from MCP package
           if [ -z "$ROOT_VERSION" ]; then
             echo "Root package.json does not have version, getting from MCP package..."
@@ -59,7 +59,7 @@ jobs:
           else
             VERSION=$ROOT_VERSION
           fi
-          
+
           echo "Using version: ${VERSION}"
           echo "PACKAGE_VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -68,6 +68,10 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }} # Use PAT for tag creation
           VERSION: ${{ steps.get_version.outputs.PACKAGE_VERSION }}
         run: |
+          # Configure git user for this repository
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           echo "Creating Git tag v${VERSION}"
           # Create an annotated tag
           git tag -a "v${VERSION}" -m "Release v${VERSION}"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-publish.yml` file. The change configures the git user for the repository to ensure that tags are created by the GitHub Actions bot.

* [`.github/workflows/release-publish.yml`](diffhunk://#diff-c6d47dacf31662f6791d0cf218b1d34ee0ab48348c037819431cdd40e3fc23e4R71-R74): Added configuration for git user name and email to ensure tags are created by the GitHub Actions bot.